### PR TITLE
Allow `Text` as a child of both `Script` and `Anchor`

### DIFF
--- a/crates/html-bindgen/src/merge/mod.rs
+++ b/crates/html-bindgen/src/merge/mod.rs
@@ -115,11 +115,14 @@ fn insert_text_content(
         let has_transparent = parent_el
             .permitted_content
             .contains(&ParsedRelationship::Category(ParsedCategory::Transparent));
+        let is_transparent = parent_el
+            .content_categories
+            .contains(&ParsedCategory::Transparent);
         let has_flow = parent_el
             .permitted_content
             .contains(&ParsedRelationship::Category(ParsedCategory::Flow));
 
-        if has_phrasing || has_flow || has_transparent {
+        if has_phrasing || has_flow || has_transparent || is_transparent {
             children_map
                 .get_mut(&parent_el.struct_name)
                 .unwrap()

--- a/crates/html-bindgen/src/merge/mod.rs
+++ b/crates/html-bindgen/src/merge/mod.rs
@@ -119,7 +119,8 @@ fn insert_text_content(
             .permitted_content
             .contains(&ParsedRelationship::Category(ParsedCategory::Flow));
 
-        if has_phrasing || has_flow || has_transparent {
+        // NOTE: `script` is a one-off, see: https://github.com/yoshuawuyts/html/issues/41
+        if has_phrasing || has_flow || has_transparent || parent_el.tag_name == "script" {
             let vec = children_map.get_mut(&parent_el.struct_name).unwrap();
             vec.push("Text".to_owned());
             vec.dedup();

--- a/crates/html-bindgen/src/merge/mod.rs
+++ b/crates/html-bindgen/src/merge/mod.rs
@@ -115,18 +115,15 @@ fn insert_text_content(
         let has_transparent = parent_el
             .permitted_content
             .contains(&ParsedRelationship::Category(ParsedCategory::Transparent));
-        let is_transparent = parent_el
-            .content_categories
-            .contains(&ParsedCategory::Transparent);
         let has_flow = parent_el
             .permitted_content
             .contains(&ParsedRelationship::Category(ParsedCategory::Flow));
 
-        if has_phrasing || has_flow || has_transparent || is_transparent {
-            children_map
-                .get_mut(&parent_el.struct_name)
-                .unwrap()
-                .push("Text".to_owned());
+        if has_phrasing || has_flow || has_transparent {
+            let vec = children_map.get_mut(&parent_el.struct_name).unwrap();
+            vec.push("Text".to_owned());
+            vec.dedup();
+            vec.sort();
         }
     }
 }

--- a/crates/html-bindgen/src/parse/elements/categories.rs
+++ b/crates/html-bindgen/src/parse/elements/categories.rs
@@ -62,6 +62,10 @@ fn parse_category(line: &str) -> Vec<String> {
         output.push(captures[1].to_owned());
     }
 
+    if line.contains("transparent") {
+        output.push("transparent".to_owned());
+    }
+
     // We just try and find this string and insert all the right headers.
     let re = regex!(r"h1, h2,[\s]+h3, h4, h5, or h6 element");
     if re.find(&line).is_some() {

--- a/crates/html-bindgen/src/parse/elements/mod.rs
+++ b/crates/html-bindgen/src/parse/elements/mod.rs
@@ -256,8 +256,8 @@ fn parse_relationships(categories: &[String], tag_names: &[String]) -> Vec<Parse
         }
     }
 
-    cat_output.dedup();
     cat_output.sort();
+    cat_output.dedup();
     cat_output
 }
 

--- a/crates/html/src/generated/a.rs
+++ b/crates/html/src/generated/a.rs
@@ -488,6 +488,8 @@ pub mod child {
         TextArea(crate::generated::all::TextArea),
         /// The Video element
         Video(crate::generated::all::Video),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Anchor> for AnchorChild {
         fn from(value: crate::generated::all::Anchor) -> Self {
@@ -549,6 +551,21 @@ pub mod child {
             Self::Video(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for AnchorChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for AnchorChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for AnchorChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl crate::Render for AnchorChild {
         fn render(
             &self,
@@ -568,6 +585,7 @@ pub mod child {
                 Self::Select(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -770,6 +788,15 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `href` attribute

--- a/crates/html/src/generated/a.rs
+++ b/crates/html/src/generated/a.rs
@@ -484,12 +484,12 @@ pub mod child {
         Label(crate::generated::all::Label),
         /// The Select element
         Select(crate::generated::all::Select),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Anchor> for AnchorChild {
         fn from(value: crate::generated::all::Anchor) -> Self {
@@ -541,16 +541,6 @@ pub mod child {
             Self::Select(value)
         }
     }
-    impl std::convert::From<crate::generated::all::TextArea> for AnchorChild {
-        fn from(value: crate::generated::all::TextArea) -> Self {
-            Self::TextArea(value)
-        }
-    }
-    impl std::convert::From<crate::generated::all::Video> for AnchorChild {
-        fn from(value: crate::generated::all::Video) -> Self {
-            Self::Video(value)
-        }
-    }
     impl std::convert::From<std::borrow::Cow<'static, str>> for AnchorChild {
         fn from(value: std::borrow::Cow<'static, str>) -> Self {
             Self::Text(value)
@@ -564,6 +554,16 @@ pub mod child {
     impl std::convert::From<String> for AnchorChild {
         fn from(value: String) -> Self {
             Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<crate::generated::all::TextArea> for AnchorChild {
+        fn from(value: crate::generated::all::TextArea) -> Self {
+            Self::TextArea(value)
+        }
+    }
+    impl std::convert::From<crate::generated::all::Video> for AnchorChild {
+        fn from(value: crate::generated::all::Video) -> Self {
+            Self::Video(value)
         }
     }
     impl crate::Render for AnchorChild {
@@ -583,9 +583,9 @@ pub mod child {
                 Self::Input(el) => crate::Render::render(el, f, depth + 1),
                 Self::Label(el) => crate::Render::render(el, f, depth + 1),
                 Self::Select(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -760,6 +760,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -788,15 +797,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `href` attribute

--- a/crates/html/src/generated/abbr.rs
+++ b/crates/html/src/generated/abbr.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for AbbreviationChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -735,6 +735,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for AbbreviationChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for AbbreviationChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for AbbreviationChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for AbbreviationChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -758,21 +773,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for AbbreviationChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for AbbreviationChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for AbbreviationChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for AbbreviationChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for AbbreviationChild {
@@ -833,12 +833,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1607,6 +1607,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1681,15 +1690,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/address.rs
+++ b/crates/html/src/generated/address.rs
@@ -530,6 +530,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -544,8 +546,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for AddressChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -940,6 +940,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for AddressChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for AddressChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for AddressChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for AddressChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -973,21 +988,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for AddressChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for AddressChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for AddressChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for AddressChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for AddressChild {
@@ -1077,6 +1077,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1084,7 +1085,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2297,6 +2297,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2403,15 +2412,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/article.rs
+++ b/crates/html/src/generated/article.rs
@@ -531,6 +531,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -545,8 +547,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for ArticleChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -941,6 +941,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for ArticleChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for ArticleChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for ArticleChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for ArticleChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -974,21 +989,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for ArticleChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for ArticleChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for ArticleChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for ArticleChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for ArticleChild {
@@ -1078,6 +1078,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1085,7 +1086,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2298,6 +2298,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2404,15 +2413,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/aside.rs
+++ b/crates/html/src/generated/aside.rs
@@ -531,6 +531,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -545,8 +547,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for AsideChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -939,6 +939,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for AsideChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for AsideChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for AsideChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for AsideChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -972,21 +987,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for AsideChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for AsideChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for AsideChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for AsideChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for AsideChild {
@@ -1076,6 +1076,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1083,7 +1084,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2296,6 +2296,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2402,15 +2411,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/audio.rs
+++ b/crates/html/src/generated/audio.rs
@@ -456,19 +456,14 @@ pub mod child {
     pub enum AudioChild {
         /// The MediaSource element
         MediaSource(crate::generated::all::MediaSource),
-        /// The TextTrack element
-        TextTrack(crate::generated::all::TextTrack),
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
+        /// The TextTrack element
+        TextTrack(crate::generated::all::TextTrack),
     }
     impl std::convert::From<crate::generated::all::MediaSource> for AudioChild {
         fn from(value: crate::generated::all::MediaSource) -> Self {
             Self::MediaSource(value)
-        }
-    }
-    impl std::convert::From<crate::generated::all::TextTrack> for AudioChild {
-        fn from(value: crate::generated::all::TextTrack) -> Self {
-            Self::TextTrack(value)
         }
     }
     impl std::convert::From<std::borrow::Cow<'static, str>> for AudioChild {
@@ -486,6 +481,11 @@ pub mod child {
             Self::Text(value.into())
         }
     }
+    impl std::convert::From<crate::generated::all::TextTrack> for AudioChild {
+        fn from(value: crate::generated::all::TextTrack) -> Self {
+            Self::TextTrack(value)
+        }
+    }
     impl crate::Render for AudioChild {
         fn render(
             &self,
@@ -494,8 +494,8 @@ pub mod child {
         ) -> std::fmt::Result {
             match self {
                 Self::MediaSource(el) => crate::Render::render(el, f, depth + 1),
-                Self::TextTrack(el) => crate::Render::render(el, f, depth + 1),
                 Self::Text(el) => crate::Render::render(el, f, depth + 1),
+                Self::TextTrack(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -544,6 +544,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextTrack` element
         pub fn text_track<F>(&mut self, f: F) -> &mut Self
         where
@@ -558,15 +567,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `src` attribute

--- a/crates/html/src/generated/audio.rs
+++ b/crates/html/src/generated/audio.rs
@@ -458,6 +458,8 @@ pub mod child {
         MediaSource(crate::generated::all::MediaSource),
         /// The TextTrack element
         TextTrack(crate::generated::all::TextTrack),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::MediaSource> for AudioChild {
         fn from(value: crate::generated::all::MediaSource) -> Self {
@@ -469,6 +471,21 @@ pub mod child {
             Self::TextTrack(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for AudioChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for AudioChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for AudioChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl crate::Render for AudioChild {
         fn render(
             &self,
@@ -478,6 +495,7 @@ pub mod child {
             match self {
                 Self::MediaSource(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextTrack(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -540,6 +558,15 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `src` attribute

--- a/crates/html/src/generated/b.rs
+++ b/crates/html/src/generated/b.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for BoldChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -732,6 +732,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for BoldChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for BoldChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for BoldChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for BoldChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -755,21 +770,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for BoldChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for BoldChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for BoldChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for BoldChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for BoldChild {
@@ -830,12 +830,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1604,6 +1604,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1678,15 +1687,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/bdi.rs
+++ b/crates/html/src/generated/bdi.rs
@@ -476,6 +476,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -486,8 +488,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation>
     for BidirectionalIsolateChild {
@@ -769,6 +769,22 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>>
+    for BidirectionalIsolateChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for BidirectionalIsolateChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for BidirectionalIsolateChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea>
     for BidirectionalIsolateChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
@@ -795,22 +811,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for BidirectionalIsolateChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>>
-    for BidirectionalIsolateChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for BidirectionalIsolateChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for BidirectionalIsolateChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for BidirectionalIsolateChild {
@@ -871,12 +871,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1645,6 +1645,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1719,15 +1728,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/bdo.rs
+++ b/crates/html/src/generated/bdo.rs
@@ -476,6 +476,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -486,8 +488,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation>
     for BidirectionalTextOverrideChild {
@@ -783,6 +783,22 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>>
+    for BidirectionalTextOverrideChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for BidirectionalTextOverrideChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for BidirectionalTextOverrideChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea>
     for BidirectionalTextOverrideChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
@@ -811,22 +827,6 @@ pub mod child {
     for BidirectionalTextOverrideChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>>
-    for BidirectionalTextOverrideChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for BidirectionalTextOverrideChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for BidirectionalTextOverrideChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for BidirectionalTextOverrideChild {
@@ -887,12 +887,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1661,6 +1661,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1735,15 +1744,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/blockquote.rs
+++ b/crates/html/src/generated/blockquote.rs
@@ -541,6 +541,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -555,8 +557,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for BlockQuoteChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -952,6 +952,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for BlockQuoteChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for BlockQuoteChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for BlockQuoteChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for BlockQuoteChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -985,21 +1000,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for BlockQuoteChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for BlockQuoteChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for BlockQuoteChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for BlockQuoteChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for BlockQuoteChild {
@@ -1089,6 +1089,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1096,7 +1097,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2309,6 +2309,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2415,15 +2424,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `cite` attribute

--- a/crates/html/src/generated/button.rs
+++ b/crates/html/src/generated/button.rs
@@ -580,6 +580,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -590,8 +592,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for ButtonChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -846,6 +846,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for ButtonChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for ButtonChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for ButtonChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for ButtonChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -869,21 +884,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for ButtonChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for ButtonChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for ButtonChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for ButtonChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for ButtonChild {
@@ -945,12 +945,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1735,6 +1735,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1809,15 +1818,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `disabled` attribute

--- a/crates/html/src/generated/canvas.rs
+++ b/crates/html/src/generated/canvas.rs
@@ -402,6 +402,8 @@ pub mod child {
         Input(crate::generated::all::Input),
         /// The Select element
         Select(crate::generated::all::Select),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Anchor> for CanvasChild {
         fn from(value: crate::generated::all::Anchor) -> Self {
@@ -428,6 +430,21 @@ pub mod child {
             Self::Select(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for CanvasChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for CanvasChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for CanvasChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl crate::Render for CanvasChild {
         fn render(
             &self,
@@ -440,6 +457,7 @@ pub mod child {
                 Self::Image(el) => crate::Render::render(el, f, depth + 1),
                 Self::Input(el) => crate::Render::render(el, f, depth + 1),
                 Self::Select(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -540,6 +558,15 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `width` attribute

--- a/crates/html/src/generated/cite.rs
+++ b/crates/html/src/generated/cite.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for CiteChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -732,6 +732,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for CiteChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for CiteChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for CiteChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for CiteChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -755,21 +770,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for CiteChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for CiteChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for CiteChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for CiteChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for CiteChild {
@@ -830,12 +830,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1604,6 +1604,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1678,15 +1687,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/code.rs
+++ b/crates/html/src/generated/code.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for CodeChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -732,6 +732,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for CodeChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for CodeChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for CodeChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for CodeChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -755,21 +770,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for CodeChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for CodeChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for CodeChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for CodeChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for CodeChild {
@@ -830,12 +830,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1604,6 +1604,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1678,15 +1687,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/data.rs
+++ b/crates/html/src/generated/data.rs
@@ -484,6 +484,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -494,8 +496,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for DataChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -743,6 +743,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DataChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DataChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DataChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for DataChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -766,21 +781,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for DataChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for DataChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for DataChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for DataChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for DataChild {
@@ -841,12 +841,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1615,6 +1615,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1689,15 +1698,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `value` attribute

--- a/crates/html/src/generated/datalist.rs
+++ b/crates/html/src/generated/datalist.rs
@@ -474,6 +474,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -484,8 +486,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for DataListChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -740,6 +740,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DataListChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DataListChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DataListChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for DataListChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -763,21 +778,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for DataListChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for DataListChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for DataListChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for DataListChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for DataListChild {
@@ -839,12 +839,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1627,6 +1627,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1701,15 +1710,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/del.rs
+++ b/crates/html/src/generated/del.rs
@@ -7,6 +7,7 @@ pub mod element {
     #[derive(Debug, PartialEq, Clone, Default)]
     pub struct DeletedText {
         sys: html_sys::edits::DeletedText,
+        children: Vec<super::child::DeletedTextChild>,
     }
     impl DeletedText {
         /// Create a new builder
@@ -341,6 +342,16 @@ pub mod element {
             self.sys.translate = value;
         }
     }
+    impl DeletedText {
+        /// Access the element's children
+        pub fn children(&self) -> &[super::child::DeletedTextChild] {
+            self.children.as_ref()
+        }
+        /// Mutably access the element's children
+        pub fn children_mut(&mut self) -> &mut Vec<super::child::DeletedTextChild> {
+            &mut self.children
+        }
+    }
     impl crate::Render for DeletedText {
         fn render(
             &self,
@@ -349,6 +360,13 @@ pub mod element {
         ) -> std::fmt::Result {
             write!(f, "{:level$}", "", level = depth * 4)?;
             html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            if !self.children.is_empty() {
+                write!(f, "\n")?;
+            }
+            for el in &self.children {
+                crate::Render::render(&el, f, depth)?;
+                write!(f, "\n")?;
+            }
             write!(f, "{:level$}", "", level = depth * 4)?;
             html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
@@ -371,11 +389,50 @@ pub mod element {
     }
     impl From<html_sys::edits::DeletedText> for DeletedText {
         fn from(sys: html_sys::edits::DeletedText) -> Self {
-            Self { sys }
+            Self { sys, children: vec![] }
         }
     }
 }
-pub mod child {}
+pub mod child {
+    /// The permitted child items for the `DeletedText` element
+    #[derive(Debug, PartialEq, Clone)]
+    pub enum DeletedTextChild {
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
+    }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DeletedTextChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DeletedTextChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DeletedTextChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl crate::Render for DeletedTextChild {
+        fn render(
+            &self,
+            f: &mut std::fmt::Formatter<'_>,
+            depth: usize,
+        ) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
+            }
+        }
+    }
+    impl std::fmt::Display for DeletedTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+}
 pub mod builder {
     /// A builder struct for DeletedText
     pub struct DeletedTextBuilder {
@@ -396,6 +453,15 @@ pub mod builder {
             value: impl Into<std::borrow::Cow<'static, str>>,
         ) -> &mut DeletedTextBuilder {
             self.element.data_map_mut().insert(data_key.into(), value.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `cite` attribute
@@ -621,6 +687,25 @@ pub mod builder {
         /// Set the value of the `translate` attribute
         pub fn translate(&mut self, value: bool) -> &mut Self {
             self.element.set_translate(value);
+            self
+        }
+        /// Push a new child element to the list of children.
+        pub fn push<T>(&mut self, child_el: T) -> &mut Self
+        where
+            T: Into<crate::generated::all::children::DeletedTextChild>,
+        {
+            let child_el = child_el.into();
+            self.element.children_mut().push(child_el);
+            self
+        }
+        /// Extend the list of children with an iterator of child elements.
+        pub fn extend<I, T>(&mut self, iter: I) -> &mut Self
+        where
+            I: IntoIterator<Item = T>,
+            T: Into<crate::generated::all::children::DeletedTextChild>,
+        {
+            let iter = iter.into_iter().map(|child_el| child_el.into());
+            self.element.children_mut().extend(iter);
             self
         }
     }

--- a/crates/html/src/generated/details.rs
+++ b/crates/html/src/generated/details.rs
@@ -541,6 +541,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -555,8 +557,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for DetailsChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -956,6 +956,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DetailsChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DetailsChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DetailsChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for DetailsChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -989,21 +1004,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for DetailsChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for DetailsChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for DetailsChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for DetailsChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for DetailsChild {
@@ -1094,6 +1094,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1101,7 +1102,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2330,6 +2330,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2436,15 +2445,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `open` attribute

--- a/crates/html/src/generated/dfn.rs
+++ b/crates/html/src/generated/dfn.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for DefinitionChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DefinitionChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DefinitionChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DefinitionChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for DefinitionChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for DefinitionChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for DefinitionChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for DefinitionChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for DefinitionChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for DefinitionChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/dialog.rs
+++ b/crates/html/src/generated/dialog.rs
@@ -537,6 +537,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -551,8 +553,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for DialogChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -947,6 +947,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DialogChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DialogChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DialogChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for DialogChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -980,21 +995,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for DialogChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for DialogChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for DialogChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for DialogChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for DialogChild {
@@ -1084,6 +1084,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1091,7 +1092,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2304,6 +2304,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2410,15 +2419,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `open` attribute

--- a/crates/html/src/generated/div.rs
+++ b/crates/html/src/generated/div.rs
@@ -534,6 +534,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -548,8 +550,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for DivisionChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -955,6 +955,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for DivisionChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for DivisionChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for DivisionChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for DivisionChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -988,21 +1003,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for DivisionChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for DivisionChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for DivisionChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for DivisionChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for DivisionChild {
@@ -1094,6 +1094,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1101,7 +1102,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2346,6 +2346,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2452,15 +2461,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/em.rs
+++ b/crates/html/src/generated/em.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for EmphasisChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for EmphasisChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for EmphasisChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for EmphasisChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for EmphasisChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for EmphasisChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for EmphasisChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for EmphasisChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for EmphasisChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for EmphasisChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/fieldset.rs
+++ b/crates/html/src/generated/fieldset.rs
@@ -562,6 +562,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -576,8 +578,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for FieldsetChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -977,6 +977,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for FieldsetChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for FieldsetChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for FieldsetChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for FieldsetChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -1010,21 +1025,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for FieldsetChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for FieldsetChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for FieldsetChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for FieldsetChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for FieldsetChild {
@@ -1115,6 +1115,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1122,7 +1123,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2349,6 +2349,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2455,15 +2464,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `disabled` attribute

--- a/crates/html/src/generated/figure.rs
+++ b/crates/html/src/generated/figure.rs
@@ -532,6 +532,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -546,8 +548,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for FigureChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -947,6 +947,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for FigureChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for FigureChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for FigureChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for FigureChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -980,21 +995,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for FigureChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for FigureChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for FigureChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for FigureChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for FigureChild {
@@ -1085,6 +1085,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1092,7 +1093,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2321,6 +2321,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2427,15 +2436,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/footer.rs
+++ b/crates/html/src/generated/footer.rs
@@ -530,6 +530,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -544,8 +546,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for FooterChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -940,6 +940,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for FooterChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for FooterChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for FooterChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for FooterChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -973,21 +988,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for FooterChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for FooterChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for FooterChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for FooterChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for FooterChild {
@@ -1077,6 +1077,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1084,7 +1085,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2297,6 +2297,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2403,15 +2412,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/form.rs
+++ b/crates/html/src/generated/form.rs
@@ -615,6 +615,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -629,8 +631,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for FormChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -1023,6 +1023,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for FormChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for FormChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for FormChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for FormChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -1056,21 +1071,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for FormChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for FormChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for FormChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for FormChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for FormChild {
@@ -1160,6 +1160,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1167,7 +1168,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2380,6 +2380,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2486,15 +2495,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accept-charset` attribute

--- a/crates/html/src/generated/h1.rs
+++ b/crates/html/src/generated/h1.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for Heading1Child {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading1Child {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for Heading1Child {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for Heading1Child {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for Heading1Child {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for Heading1Child {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading1Child {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for Heading1Child {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for Heading1Child {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for Heading1Child {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/h2.rs
+++ b/crates/html/src/generated/h2.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for Heading2Child {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading2Child {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for Heading2Child {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for Heading2Child {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for Heading2Child {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for Heading2Child {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading2Child {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for Heading2Child {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for Heading2Child {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for Heading2Child {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/h3.rs
+++ b/crates/html/src/generated/h3.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for Heading3Child {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading3Child {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for Heading3Child {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for Heading3Child {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for Heading3Child {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for Heading3Child {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading3Child {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for Heading3Child {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for Heading3Child {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for Heading3Child {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/h4.rs
+++ b/crates/html/src/generated/h4.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for Heading4Child {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading4Child {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for Heading4Child {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for Heading4Child {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for Heading4Child {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for Heading4Child {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading4Child {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for Heading4Child {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for Heading4Child {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for Heading4Child {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/h5.rs
+++ b/crates/html/src/generated/h5.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for Heading5Child {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading5Child {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for Heading5Child {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for Heading5Child {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for Heading5Child {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for Heading5Child {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading5Child {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for Heading5Child {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for Heading5Child {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for Heading5Child {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/h6.rs
+++ b/crates/html/src/generated/h6.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for Heading6Child {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading6Child {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for Heading6Child {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for Heading6Child {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for Heading6Child {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for Heading6Child {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for Heading6Child {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for Heading6Child {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for Heading6Child {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for Heading6Child {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/header.rs
+++ b/crates/html/src/generated/header.rs
@@ -530,6 +530,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -544,8 +546,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for HeaderChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -940,6 +940,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for HeaderChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for HeaderChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for HeaderChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for HeaderChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -973,21 +988,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for HeaderChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for HeaderChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for HeaderChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for HeaderChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for HeaderChild {
@@ -1077,6 +1077,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1084,7 +1085,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2297,6 +2297,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2403,15 +2412,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/i.rs
+++ b/crates/html/src/generated/i.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for ItalicChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for ItalicChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for ItalicChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for ItalicChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for ItalicChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for ItalicChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for ItalicChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for ItalicChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for ItalicChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for ItalicChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/ins.rs
+++ b/crates/html/src/generated/ins.rs
@@ -7,6 +7,7 @@ pub mod element {
     #[derive(Debug, PartialEq, Clone, Default)]
     pub struct InsertedText {
         sys: html_sys::edits::InsertedText,
+        children: Vec<super::child::InsertedTextChild>,
     }
     impl InsertedText {
         /// Create a new builder
@@ -341,6 +342,16 @@ pub mod element {
             self.sys.translate = value;
         }
     }
+    impl InsertedText {
+        /// Access the element's children
+        pub fn children(&self) -> &[super::child::InsertedTextChild] {
+            self.children.as_ref()
+        }
+        /// Mutably access the element's children
+        pub fn children_mut(&mut self) -> &mut Vec<super::child::InsertedTextChild> {
+            &mut self.children
+        }
+    }
     impl crate::Render for InsertedText {
         fn render(
             &self,
@@ -349,6 +360,13 @@ pub mod element {
         ) -> std::fmt::Result {
             write!(f, "{:level$}", "", level = depth * 4)?;
             html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            if !self.children.is_empty() {
+                write!(f, "\n")?;
+            }
+            for el in &self.children {
+                crate::Render::render(&el, f, depth)?;
+                write!(f, "\n")?;
+            }
             write!(f, "{:level$}", "", level = depth * 4)?;
             html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
@@ -371,11 +389,50 @@ pub mod element {
     }
     impl From<html_sys::edits::InsertedText> for InsertedText {
         fn from(sys: html_sys::edits::InsertedText) -> Self {
-            Self { sys }
+            Self { sys, children: vec![] }
         }
     }
 }
-pub mod child {}
+pub mod child {
+    /// The permitted child items for the `InsertedText` element
+    #[derive(Debug, PartialEq, Clone)]
+    pub enum InsertedTextChild {
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
+    }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for InsertedTextChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for InsertedTextChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for InsertedTextChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl crate::Render for InsertedTextChild {
+        fn render(
+            &self,
+            f: &mut std::fmt::Formatter<'_>,
+            depth: usize,
+        ) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
+            }
+        }
+    }
+    impl std::fmt::Display for InsertedTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+}
 pub mod builder {
     /// A builder struct for InsertedText
     pub struct InsertedTextBuilder {
@@ -396,6 +453,15 @@ pub mod builder {
             value: impl Into<std::borrow::Cow<'static, str>>,
         ) -> &mut InsertedTextBuilder {
             self.element.data_map_mut().insert(data_key.into(), value.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `cite` attribute
@@ -621,6 +687,25 @@ pub mod builder {
         /// Set the value of the `translate` attribute
         pub fn translate(&mut self, value: bool) -> &mut Self {
             self.element.set_translate(value);
+            self
+        }
+        /// Push a new child element to the list of children.
+        pub fn push<T>(&mut self, child_el: T) -> &mut Self
+        where
+            T: Into<crate::generated::all::children::InsertedTextChild>,
+        {
+            let child_el = child_el.into();
+            self.element.children_mut().push(child_el);
+            self
+        }
+        /// Extend the list of children with an iterator of child elements.
+        pub fn extend<I, T>(&mut self, iter: I) -> &mut Self
+        where
+            I: IntoIterator<Item = T>,
+            T: Into<crate::generated::all::children::InsertedTextChild>,
+        {
+            let iter = iter.into_iter().map(|child_el| child_el.into());
+            self.element.children_mut().extend(iter);
             self
         }
     }

--- a/crates/html/src/generated/kbd.rs
+++ b/crates/html/src/generated/kbd.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for KeyboardInputChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -737,6 +737,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for KeyboardInputChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for KeyboardInputChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for KeyboardInputChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for KeyboardInputChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -760,21 +775,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for KeyboardInputChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for KeyboardInputChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for KeyboardInputChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for KeyboardInputChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for KeyboardInputChild {
@@ -835,12 +835,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1609,6 +1609,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1683,15 +1692,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/label.rs
+++ b/crates/html/src/generated/label.rs
@@ -485,6 +485,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -495,8 +497,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for LabelChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -744,6 +744,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for LabelChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for LabelChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for LabelChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for LabelChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -767,21 +782,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for LabelChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for LabelChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for LabelChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for LabelChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for LabelChild {
@@ -842,12 +842,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1616,6 +1616,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1690,15 +1699,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `for` attribute

--- a/crates/html/src/generated/main.rs
+++ b/crates/html/src/generated/main.rs
@@ -530,6 +530,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -544,8 +546,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for MainChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -938,6 +938,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for MainChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for MainChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for MainChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for MainChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -971,21 +986,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for MainChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for MainChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for MainChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for MainChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for MainChild {
@@ -1075,6 +1075,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1082,7 +1083,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2295,6 +2295,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2401,15 +2410,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/mark.rs
+++ b/crates/html/src/generated/mark.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for MarkTextChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for MarkTextChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for MarkTextChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for MarkTextChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for MarkTextChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for MarkTextChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for MarkTextChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for MarkTextChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for MarkTextChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for MarkTextChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/meter.rs
+++ b/crates/html/src/generated/meter.rs
@@ -521,6 +521,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -531,8 +533,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for MeterChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -780,6 +780,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for MeterChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for MeterChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for MeterChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for MeterChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -803,21 +818,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for MeterChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for MeterChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for MeterChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for MeterChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for MeterChild {
@@ -878,12 +878,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1652,6 +1652,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1726,15 +1735,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `value` attribute

--- a/crates/html/src/generated/nav.rs
+++ b/crates/html/src/generated/nav.rs
@@ -531,6 +531,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -545,8 +547,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for NavigationChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -942,6 +942,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for NavigationChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for NavigationChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for NavigationChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for NavigationChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -975,21 +990,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for NavigationChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for NavigationChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for NavigationChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for NavigationChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for NavigationChild {
@@ -1079,6 +1079,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1086,7 +1087,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2299,6 +2299,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2405,15 +2414,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/noscript.rs
+++ b/crates/html/src/generated/noscript.rs
@@ -375,6 +375,8 @@ pub mod child {
     /// The permitted child items for the `NoScript` element
     #[derive(Debug, PartialEq, Clone)]
     pub enum NoScriptChild {
+        /// The Head element
+        Head(crate::generated::all::Head),
         /// The Link element
         Link(crate::generated::all::Link),
         /// The Meta element
@@ -383,6 +385,11 @@ pub mod child {
         Style(crate::generated::all::Style),
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
+    }
+    impl std::convert::From<crate::generated::all::Head> for NoScriptChild {
+        fn from(value: crate::generated::all::Head) -> Self {
+            Self::Head(value)
+        }
     }
     impl std::convert::From<crate::generated::all::Link> for NoScriptChild {
         fn from(value: crate::generated::all::Link) -> Self {
@@ -421,6 +428,7 @@ pub mod child {
             depth: usize,
         ) -> std::fmt::Result {
             match self {
+                Self::Head(el) => crate::Render::render(el, f, depth + 1),
                 Self::Link(el) => crate::Render::render(el, f, depth + 1),
                 Self::Meta(el) => crate::Render::render(el, f, depth + 1),
                 Self::Style(el) => crate::Render::render(el, f, depth + 1),
@@ -455,6 +463,20 @@ pub mod builder {
             value: impl Into<std::borrow::Cow<'static, str>>,
         ) -> &mut NoScriptBuilder {
             self.element.data_map_mut().insert(data_key.into(), value.into());
+            self
+        }
+        /// Append a new `Head` element
+        pub fn head<F>(&mut self, f: F) -> &mut Self
+        where
+            F: for<'a> FnOnce(
+                &'a mut crate::generated::all::builders::HeadBuilder,
+            ) -> &'a mut crate::generated::all::builders::HeadBuilder,
+        {
+            let ty: crate::generated::all::Head = Default::default();
+            let mut ty_builder = crate::generated::all::builders::HeadBuilder::new(ty);
+            (f)(&mut ty_builder);
+            let ty = ty_builder.build();
+            self.element.children_mut().push(ty.into());
             self
         }
         /// Append a new `Link` element

--- a/crates/html/src/generated/output.rs
+++ b/crates/html/src/generated/output.rs
@@ -506,6 +506,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -516,8 +518,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for OutputChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -767,6 +767,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for OutputChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for OutputChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for OutputChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for OutputChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -790,21 +805,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for OutputChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for OutputChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for OutputChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for OutputChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for OutputChild {
@@ -865,12 +865,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1639,6 +1639,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1713,15 +1722,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `for` attribute

--- a/crates/html/src/generated/p.rs
+++ b/crates/html/src/generated/p.rs
@@ -472,6 +472,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -482,8 +484,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for ParagraphChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -733,6 +733,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for ParagraphChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for ParagraphChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for ParagraphChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for ParagraphChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -756,21 +771,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for ParagraphChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for ParagraphChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for ParagraphChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for ParagraphChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for ParagraphChild {
@@ -831,12 +831,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1605,6 +1605,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1679,15 +1688,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/pre.rs
+++ b/crates/html/src/generated/pre.rs
@@ -472,6 +472,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -482,8 +484,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation>
     for PreformattedTextChild {
@@ -744,6 +744,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for PreformattedTextChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for PreformattedTextChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for PreformattedTextChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for PreformattedTextChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -767,21 +782,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for PreformattedTextChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for PreformattedTextChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for PreformattedTextChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for PreformattedTextChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for PreformattedTextChild {
@@ -842,12 +842,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1616,6 +1616,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1690,15 +1699,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/progress.rs
+++ b/crates/html/src/generated/progress.rs
@@ -489,6 +489,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -499,8 +501,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for ProgressChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -750,6 +750,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for ProgressChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for ProgressChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for ProgressChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for ProgressChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -773,21 +788,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for ProgressChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for ProgressChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for ProgressChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for ProgressChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for ProgressChild {
@@ -848,12 +848,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1622,6 +1622,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1696,15 +1705,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `value` attribute

--- a/crates/html/src/generated/q.rs
+++ b/crates/html/src/generated/q.rs
@@ -484,6 +484,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -494,8 +496,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for QuotationChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -745,6 +745,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for QuotationChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for QuotationChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for QuotationChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for QuotationChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -768,21 +783,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for QuotationChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for QuotationChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for QuotationChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for QuotationChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for QuotationChild {
@@ -843,12 +843,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1617,6 +1617,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1691,15 +1700,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `cite` attribute

--- a/crates/html/src/generated/s.rs
+++ b/crates/html/src/generated/s.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for StrikeThroughChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -737,6 +737,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for StrikeThroughChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for StrikeThroughChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for StrikeThroughChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for StrikeThroughChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -760,21 +775,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for StrikeThroughChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for StrikeThroughChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for StrikeThroughChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for StrikeThroughChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for StrikeThroughChild {
@@ -835,12 +835,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1609,6 +1609,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1683,15 +1692,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/samp.rs
+++ b/crates/html/src/generated/samp.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SampleOutputChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -735,6 +735,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SampleOutputChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SampleOutputChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SampleOutputChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SampleOutputChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -758,21 +773,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SampleOutputChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SampleOutputChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SampleOutputChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SampleOutputChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SampleOutputChild {
@@ -833,12 +833,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1607,6 +1607,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1681,15 +1690,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/script.rs
+++ b/crates/html/src/generated/script.rs
@@ -488,10 +488,27 @@ pub mod child {
     pub enum ScriptChild {
         /// The Script element
         Script(crate::generated::all::Script),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Script> for ScriptChild {
         fn from(value: crate::generated::all::Script) -> Self {
             Self::Script(value)
+        }
+    }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for ScriptChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for ScriptChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for ScriptChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
         }
     }
     impl crate::Render for ScriptChild {
@@ -502,6 +519,7 @@ pub mod child {
         ) -> std::fmt::Result {
             match self {
                 Self::Script(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -546,6 +564,15 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `src` attribute

--- a/crates/html/src/generated/search.rs
+++ b/crates/html/src/generated/search.rs
@@ -530,6 +530,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -544,8 +546,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SearchChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -940,6 +940,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SearchChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SearchChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SearchChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SearchChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -973,21 +988,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SearchChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SearchChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SearchChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SearchChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SearchChild {
@@ -1077,6 +1077,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1084,7 +1085,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2297,6 +2297,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2403,15 +2412,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/section.rs
+++ b/crates/html/src/generated/section.rs
@@ -531,6 +531,8 @@ pub mod child {
         Table(crate::generated::all::Table),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The ThematicBreak element
@@ -545,8 +547,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SectionChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -941,6 +941,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SectionChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SectionChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SectionChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SectionChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -974,21 +989,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SectionChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SectionChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SectionChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SectionChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SectionChild {
@@ -1078,6 +1078,7 @@ pub mod child {
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Table(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::ThematicBreak(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
@@ -1085,7 +1086,6 @@ pub mod child {
                 Self::UnorderedList(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -2298,6 +2298,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -2404,15 +2413,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/slot.rs
+++ b/crates/html/src/generated/slot.rs
@@ -7,6 +7,7 @@ pub mod element {
     #[derive(Debug, PartialEq, Clone, Default)]
     pub struct Slot {
         sys: html_sys::scripting::Slot,
+        children: Vec<super::child::SlotChild>,
     }
     impl Slot {
         /// Create a new builder
@@ -330,6 +331,16 @@ pub mod element {
             self.sys.translate = value;
         }
     }
+    impl Slot {
+        /// Access the element's children
+        pub fn children(&self) -> &[super::child::SlotChild] {
+            self.children.as_ref()
+        }
+        /// Mutably access the element's children
+        pub fn children_mut(&mut self) -> &mut Vec<super::child::SlotChild> {
+            &mut self.children
+        }
+    }
     impl crate::Render for Slot {
         fn render(
             &self,
@@ -338,6 +349,13 @@ pub mod element {
         ) -> std::fmt::Result {
             write!(f, "{:level$}", "", level = depth * 4)?;
             html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            if !self.children.is_empty() {
+                write!(f, "\n")?;
+            }
+            for el in &self.children {
+                crate::Render::render(&el, f, depth)?;
+                write!(f, "\n")?;
+            }
             write!(f, "{:level$}", "", level = depth * 4)?;
             html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
@@ -359,11 +377,50 @@ pub mod element {
     }
     impl From<html_sys::scripting::Slot> for Slot {
         fn from(sys: html_sys::scripting::Slot) -> Self {
-            Self { sys }
+            Self { sys, children: vec![] }
         }
     }
 }
-pub mod child {}
+pub mod child {
+    /// The permitted child items for the `Slot` element
+    #[derive(Debug, PartialEq, Clone)]
+    pub enum SlotChild {
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
+    }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SlotChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SlotChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SlotChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl crate::Render for SlotChild {
+        fn render(
+            &self,
+            f: &mut std::fmt::Formatter<'_>,
+            depth: usize,
+        ) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
+            }
+        }
+    }
+    impl std::fmt::Display for SlotChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+}
 pub mod builder {
     /// A builder struct for Slot
     pub struct SlotBuilder {
@@ -384,6 +441,15 @@ pub mod builder {
             value: impl Into<std::borrow::Cow<'static, str>>,
         ) -> &mut SlotBuilder {
             self.element.data_map_mut().insert(data_key.into(), value.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `name` attribute
@@ -601,6 +667,25 @@ pub mod builder {
         /// Set the value of the `translate` attribute
         pub fn translate(&mut self, value: bool) -> &mut Self {
             self.element.set_translate(value);
+            self
+        }
+        /// Push a new child element to the list of children.
+        pub fn push<T>(&mut self, child_el: T) -> &mut Self
+        where
+            T: Into<crate::generated::all::children::SlotChild>,
+        {
+            let child_el = child_el.into();
+            self.element.children_mut().push(child_el);
+            self
+        }
+        /// Extend the list of children with an iterator of child elements.
+        pub fn extend<I, T>(&mut self, iter: I) -> &mut Self
+        where
+            I: IntoIterator<Item = T>,
+            T: Into<crate::generated::all::children::SlotChild>,
+        {
+            let iter = iter.into_iter().map(|child_el| child_el.into());
+            self.element.children_mut().extend(iter);
             self
         }
     }

--- a/crates/html/src/generated/small.rs
+++ b/crates/html/src/generated/small.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SideCommentChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SideCommentChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SideCommentChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SideCommentChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SideCommentChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SideCommentChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SideCommentChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SideCommentChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SideCommentChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SideCommentChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/span.rs
+++ b/crates/html/src/generated/span.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SpanChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -732,6 +732,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SpanChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SpanChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SpanChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SpanChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -755,21 +770,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SpanChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SpanChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SpanChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SpanChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SpanChild {
@@ -830,12 +830,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1604,6 +1604,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1678,15 +1687,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/strong.rs
+++ b/crates/html/src/generated/strong.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for StrongChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for StrongChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for StrongChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for StrongChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for StrongChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for StrongChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for StrongChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for StrongChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for StrongChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for StrongChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/sub.rs
+++ b/crates/html/src/generated/sub.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SubScriptChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SubScriptChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SubScriptChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SubScriptChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SubScriptChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SubScriptChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SubScriptChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SubScriptChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SubScriptChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SubScriptChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/sup.rs
+++ b/crates/html/src/generated/sup.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for SuperScriptChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for SuperScriptChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for SuperScriptChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for SuperScriptChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for SuperScriptChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for SuperScriptChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for SuperScriptChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for SuperScriptChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for SuperScriptChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for SuperScriptChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/time.rs
+++ b/crates/html/src/generated/time.rs
@@ -484,6 +484,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -494,8 +496,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for TimeChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -743,6 +743,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for TimeChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for TimeChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for TimeChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for TimeChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -766,21 +781,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for TimeChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for TimeChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for TimeChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for TimeChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for TimeChild {
@@ -841,12 +841,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1615,6 +1615,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1689,15 +1698,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `datetime` attribute

--- a/crates/html/src/generated/u.rs
+++ b/crates/html/src/generated/u.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for UnderlineChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for UnderlineChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for UnderlineChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for UnderlineChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for UnderlineChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for UnderlineChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for UnderlineChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for UnderlineChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for UnderlineChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for UnderlineChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/var.rs
+++ b/crates/html/src/generated/var.rs
@@ -473,6 +473,8 @@ pub mod child {
         SuperScript(crate::generated::all::SuperScript),
         /// The Template element
         Template(crate::generated::all::Template),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
         /// The TextArea element
         TextArea(crate::generated::all::TextArea),
         /// The Time element
@@ -483,8 +485,6 @@ pub mod child {
         Variable(crate::generated::all::Variable),
         /// The Video element
         Video(crate::generated::all::Video),
-        /// The Text element
-        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::Abbreviation> for VariableChild {
         fn from(value: crate::generated::all::Abbreviation) -> Self {
@@ -734,6 +734,21 @@ pub mod child {
             Self::Template(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for VariableChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for VariableChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for VariableChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl std::convert::From<crate::generated::all::TextArea> for VariableChild {
         fn from(value: crate::generated::all::TextArea) -> Self {
             Self::TextArea(value)
@@ -757,21 +772,6 @@ pub mod child {
     impl std::convert::From<crate::generated::all::Video> for VariableChild {
         fn from(value: crate::generated::all::Video) -> Self {
             Self::Video(value)
-        }
-    }
-    impl std::convert::From<std::borrow::Cow<'static, str>> for VariableChild {
-        fn from(value: std::borrow::Cow<'static, str>) -> Self {
-            Self::Text(value)
-        }
-    }
-    impl std::convert::From<&'static str> for VariableChild {
-        fn from(value: &'static str) -> Self {
-            Self::Text(value.into())
-        }
-    }
-    impl std::convert::From<String> for VariableChild {
-        fn from(value: String) -> Self {
-            Self::Text(value.into())
         }
     }
     impl crate::Render for VariableChild {
@@ -832,12 +832,12 @@ pub mod child {
                 Self::SubScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::SuperScript(el) => crate::Render::render(el, f, depth + 1),
                 Self::Template(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextArea(el) => crate::Render::render(el, f, depth + 1),
                 Self::Time(el) => crate::Render::render(el, f, depth + 1),
                 Self::Underline(el) => crate::Render::render(el, f, depth + 1),
                 Self::Variable(el) => crate::Render::render(el, f, depth + 1),
                 Self::Video(el) => crate::Render::render(el, f, depth + 1),
-                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -1606,6 +1606,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextArea` element
         pub fn text_area<F>(&mut self, f: F) -> &mut Self
         where
@@ -1680,15 +1689,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/crates/html/src/generated/video.rs
+++ b/crates/html/src/generated/video.rs
@@ -491,19 +491,14 @@ pub mod child {
     pub enum VideoChild {
         /// The MediaSource element
         MediaSource(crate::generated::all::MediaSource),
-        /// The TextTrack element
-        TextTrack(crate::generated::all::TextTrack),
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
+        /// The TextTrack element
+        TextTrack(crate::generated::all::TextTrack),
     }
     impl std::convert::From<crate::generated::all::MediaSource> for VideoChild {
         fn from(value: crate::generated::all::MediaSource) -> Self {
             Self::MediaSource(value)
-        }
-    }
-    impl std::convert::From<crate::generated::all::TextTrack> for VideoChild {
-        fn from(value: crate::generated::all::TextTrack) -> Self {
-            Self::TextTrack(value)
         }
     }
     impl std::convert::From<std::borrow::Cow<'static, str>> for VideoChild {
@@ -521,6 +516,11 @@ pub mod child {
             Self::Text(value.into())
         }
     }
+    impl std::convert::From<crate::generated::all::TextTrack> for VideoChild {
+        fn from(value: crate::generated::all::TextTrack) -> Self {
+            Self::TextTrack(value)
+        }
+    }
     impl crate::Render for VideoChild {
         fn render(
             &self,
@@ -529,8 +529,8 @@ pub mod child {
         ) -> std::fmt::Result {
             match self {
                 Self::MediaSource(el) => crate::Render::render(el, f, depth + 1),
-                Self::TextTrack(el) => crate::Render::render(el, f, depth + 1),
                 Self::Text(el) => crate::Render::render(el, f, depth + 1),
+                Self::TextTrack(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -579,6 +579,15 @@ pub mod builder {
             self.element.children_mut().push(ty.into());
             self
         }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
+            self
+        }
         /// Append a new `TextTrack` element
         pub fn text_track<F>(&mut self, f: F) -> &mut Self
         where
@@ -593,15 +602,6 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
-            self
-        }
-        /// Append a new text element.
-        pub fn text(
-            &mut self,
-            s: impl Into<std::borrow::Cow<'static, str>>,
-        ) -> &mut Self {
-            let cow = s.into();
-            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `src` attribute

--- a/crates/html/src/generated/video.rs
+++ b/crates/html/src/generated/video.rs
@@ -493,6 +493,8 @@ pub mod child {
         MediaSource(crate::generated::all::MediaSource),
         /// The TextTrack element
         TextTrack(crate::generated::all::TextTrack),
+        /// The Text element
+        Text(std::borrow::Cow<'static, str>),
     }
     impl std::convert::From<crate::generated::all::MediaSource> for VideoChild {
         fn from(value: crate::generated::all::MediaSource) -> Self {
@@ -504,6 +506,21 @@ pub mod child {
             Self::TextTrack(value)
         }
     }
+    impl std::convert::From<std::borrow::Cow<'static, str>> for VideoChild {
+        fn from(value: std::borrow::Cow<'static, str>) -> Self {
+            Self::Text(value)
+        }
+    }
+    impl std::convert::From<&'static str> for VideoChild {
+        fn from(value: &'static str) -> Self {
+            Self::Text(value.into())
+        }
+    }
+    impl std::convert::From<String> for VideoChild {
+        fn from(value: String) -> Self {
+            Self::Text(value.into())
+        }
+    }
     impl crate::Render for VideoChild {
         fn render(
             &self,
@@ -513,6 +530,7 @@ pub mod child {
             match self {
                 Self::MediaSource(el) => crate::Render::render(el, f, depth + 1),
                 Self::TextTrack(el) => crate::Render::render(el, f, depth + 1),
+                Self::Text(el) => crate::Render::render(el, f, depth + 1),
             }
         }
     }
@@ -575,6 +593,15 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Append a new text element.
+        pub fn text(
+            &mut self,
+            s: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            let cow = s.into();
+            self.element.children_mut().push(cow.into());
             self
         }
         /// Set the value of the `src` attribute

--- a/resources/merged/elements/a.json
+++ b/resources/merged/elements/a.json
@@ -74,6 +74,7 @@
     "Label",
     "Select",
     "TextArea",
-    "Video"
+    "Video",
+    "Text"
   ]
 }

--- a/resources/merged/elements/a.json
+++ b/resources/merged/elements/a.json
@@ -73,8 +73,8 @@
     "Input",
     "Label",
     "Select",
+    "Text",
     "TextArea",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/abbr.json
+++ b/resources/merged/elements/abbr.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/address.json
+++ b/resources/merged/elements/address.json
@@ -90,13 +90,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/article.json
+++ b/resources/merged/elements/article.json
@@ -91,13 +91,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/aside.json
+++ b/resources/merged/elements/aside.json
@@ -91,13 +91,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/audio.json
+++ b/resources/merged/elements/audio.json
@@ -59,6 +59,7 @@
   ],
   "permitted_child_elements": [
     "MediaSource",
-    "TextTrack"
+    "TextTrack",
+    "Text"
   ]
 }

--- a/resources/merged/elements/audio.json
+++ b/resources/merged/elements/audio.json
@@ -59,7 +59,7 @@
   ],
   "permitted_child_elements": [
     "MediaSource",
-    "TextTrack",
-    "Text"
+    "Text",
+    "TextTrack"
   ]
 }

--- a/resources/merged/elements/b.json
+++ b/resources/merged/elements/b.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/bdi.json
+++ b/resources/merged/elements/bdi.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/bdo.json
+++ b/resources/merged/elements/bdo.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/blockquote.json
+++ b/resources/merged/elements/blockquote.json
@@ -97,13 +97,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/button.json
+++ b/resources/merged/elements/button.json
@@ -125,11 +125,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/canvas.json
+++ b/resources/merged/elements/canvas.json
@@ -31,6 +31,7 @@
     "Button",
     "Image",
     "Input",
-    "Select"
+    "Select",
+    "Text"
   ]
 }

--- a/resources/merged/elements/cite.json
+++ b/resources/merged/elements/cite.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/code.json
+++ b/resources/merged/elements/code.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/data.json
+++ b/resources/merged/elements/data.json
@@ -69,11 +69,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/datalist.json
+++ b/resources/merged/elements/datalist.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/del.json
+++ b/resources/merged/elements/del.json
@@ -25,5 +25,7 @@
     "Phrasing",
     "Palpable"
   ],
-  "permitted_child_elements": []
+  "permitted_child_elements": [
+    "Text"
+  ]
 }

--- a/resources/merged/elements/details.json
+++ b/resources/merged/elements/details.json
@@ -99,13 +99,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/dfn.json
+++ b/resources/merged/elements/dfn.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/dialog.json
+++ b/resources/merged/elements/dialog.json
@@ -96,13 +96,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/div.json
+++ b/resources/merged/elements/div.json
@@ -92,13 +92,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/em.json
+++ b/resources/merged/elements/em.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/fieldset.json
+++ b/resources/merged/elements/fieldset.json
@@ -110,13 +110,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/figure.json
+++ b/resources/merged/elements/figure.json
@@ -91,13 +91,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/footer.json
+++ b/resources/merged/elements/footer.json
@@ -90,13 +90,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/form.json
+++ b/resources/merged/elements/form.json
@@ -139,13 +139,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/h1.json
+++ b/resources/merged/elements/h1.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/h2.json
+++ b/resources/merged/elements/h2.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/h3.json
+++ b/resources/merged/elements/h3.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/h4.json
+++ b/resources/merged/elements/h4.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/h5.json
+++ b/resources/merged/elements/h5.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/h6.json
+++ b/resources/merged/elements/h6.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/header.json
+++ b/resources/merged/elements/header.json
@@ -90,13 +90,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/i.json
+++ b/resources/merged/elements/i.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/ins.json
+++ b/resources/merged/elements/ins.json
@@ -25,5 +25,7 @@
     "Phrasing",
     "Palpable"
   ],
-  "permitted_child_elements": []
+  "permitted_child_elements": [
+    "Text"
+  ]
 }

--- a/resources/merged/elements/kbd.json
+++ b/resources/merged/elements/kbd.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/label.json
+++ b/resources/merged/elements/label.json
@@ -70,11 +70,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/main.json
+++ b/resources/merged/elements/main.json
@@ -90,13 +90,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/map.json
+++ b/resources/merged/elements/map.json
@@ -19,5 +19,7 @@
     "Phrasing",
     "Palpable"
   ],
-  "permitted_child_elements": []
+  "permitted_child_elements": [
+    "Text"
+  ]
 }

--- a/resources/merged/elements/mark.json
+++ b/resources/merged/elements/mark.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/meter.json
+++ b/resources/merged/elements/meter.json
@@ -99,11 +99,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/nav.json
+++ b/resources/merged/elements/nav.json
@@ -91,13 +91,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/noscript.json
+++ b/resources/merged/elements/noscript.json
@@ -13,6 +13,7 @@
     "Phrasing"
   ],
   "permitted_child_elements": [
+    "Head",
     "Link",
     "Meta",
     "Style",

--- a/resources/merged/elements/object.json
+++ b/resources/merged/elements/object.json
@@ -50,5 +50,7 @@
     "Embedded",
     "Palpable"
   ],
-  "permitted_child_elements": []
+  "permitted_child_elements": [
+    "Text"
+  ]
 }

--- a/resources/merged/elements/output.json
+++ b/resources/merged/elements/output.json
@@ -81,11 +81,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/p.json
+++ b/resources/merged/elements/p.json
@@ -61,11 +61,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/pre.json
+++ b/resources/merged/elements/pre.json
@@ -61,11 +61,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/progress.json
+++ b/resources/merged/elements/progress.json
@@ -75,11 +75,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/q.json
+++ b/resources/merged/elements/q.json
@@ -69,11 +69,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/s.json
+++ b/resources/merged/elements/s.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/samp.json
+++ b/resources/merged/elements/samp.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/script.json
+++ b/resources/merged/elements/script.json
@@ -75,6 +75,7 @@
     "ScriptSupporting"
   ],
   "permitted_child_elements": [
-    "Script"
+    "Script",
+    "Text"
   ]
 }

--- a/resources/merged/elements/search.json
+++ b/resources/merged/elements/search.json
@@ -90,13 +90,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/section.json
+++ b/resources/merged/elements/section.json
@@ -91,13 +91,13 @@
     "SuperScript",
     "Table",
     "Template",
+    "Text",
     "TextArea",
     "ThematicBreak",
     "Time",
     "Underline",
     "UnorderedList",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/slot.json
+++ b/resources/merged/elements/slot.json
@@ -18,5 +18,7 @@
     "Flow",
     "Phrasing"
   ],
-  "permitted_child_elements": []
+  "permitted_child_elements": [
+    "Text"
+  ]
 }

--- a/resources/merged/elements/small.json
+++ b/resources/merged/elements/small.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/span.json
+++ b/resources/merged/elements/span.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/strong.json
+++ b/resources/merged/elements/strong.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/sub.json
+++ b/resources/merged/elements/sub.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/sup.json
+++ b/resources/merged/elements/sup.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/time.json
+++ b/resources/merged/elements/time.json
@@ -69,11 +69,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/u.json
+++ b/resources/merged/elements/u.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/var.json
+++ b/resources/merged/elements/var.json
@@ -62,11 +62,11 @@
     "SubScript",
     "SuperScript",
     "Template",
+    "Text",
     "TextArea",
     "Time",
     "Underline",
     "Variable",
-    "Video",
-    "Text"
+    "Video"
   ]
 }

--- a/resources/merged/elements/video.json
+++ b/resources/merged/elements/video.json
@@ -83,6 +83,7 @@
   ],
   "permitted_child_elements": [
     "MediaSource",
-    "TextTrack"
+    "TextTrack",
+    "Text"
   ]
 }

--- a/resources/merged/elements/video.json
+++ b/resources/merged/elements/video.json
@@ -83,7 +83,7 @@
   ],
   "permitted_child_elements": [
     "MediaSource",
-    "TextTrack",
-    "Text"
+    "Text",
+    "TextTrack"
   ]
 }

--- a/resources/parsed/elements/a.json
+++ b/resources/parsed/elements/a.json
@@ -68,6 +68,9 @@
     },
     {
       "Category": "Interactive"
+    },
+    {
+      "Category": "Transparent"
     }
   ],
   "permitted_parents": [

--- a/resources/parsed/elements/audio.json
+++ b/resources/parsed/elements/audio.json
@@ -65,7 +65,7 @@
       "Element": "TextTrack"
     },
     {
-      "Element": "TextTrack"
+      "Category": "Transparent"
     }
   ],
   "permitted_parents": [

--- a/resources/parsed/elements/canvas.json
+++ b/resources/parsed/elements/canvas.json
@@ -41,6 +41,9 @@
     },
     {
       "Element": "Select"
+    },
+    {
+      "Category": "Transparent"
     }
   ],
   "permitted_parents": [

--- a/resources/parsed/elements/del.json
+++ b/resources/parsed/elements/del.json
@@ -25,7 +25,11 @@
     "Phrasing",
     "Palpable"
   ],
-  "permitted_content": [],
+  "permitted_content": [
+    {
+      "Category": "Transparent"
+    }
+  ],
   "permitted_parents": [
     {
       "Category": "Flow"

--- a/resources/parsed/elements/div.json
+++ b/resources/parsed/elements/div.json
@@ -19,9 +19,6 @@
       "Element": "DescriptionList"
     },
     {
-      "Element": "DescriptionList"
-    },
-    {
       "Element": "DescriptionTerm"
     },
     {

--- a/resources/parsed/elements/dl.json
+++ b/resources/parsed/elements/dl.json
@@ -23,9 +23,6 @@
     },
     {
       "Category": "ScriptSupporting"
-    },
-    {
-      "Category": "ScriptSupporting"
     }
   ],
   "permitted_parents": [

--- a/resources/parsed/elements/figure.json
+++ b/resources/parsed/elements/figure.json
@@ -16,12 +16,6 @@
       "Element": "FigureCaption"
     },
     {
-      "Element": "FigureCaption"
-    },
-    {
-      "Category": "Flow"
-    },
-    {
       "Category": "Flow"
     }
   ],

--- a/resources/parsed/elements/head.json
+++ b/resources/parsed/elements/head.json
@@ -13,16 +13,7 @@
       "Element": "Base"
     },
     {
-      "Element": "Base"
-    },
-    {
       "Element": "Title"
-    },
-    {
-      "Element": "Title"
-    },
-    {
-      "Category": "Metadata"
     },
     {
       "Category": "Metadata"

--- a/resources/parsed/elements/ins.json
+++ b/resources/parsed/elements/ins.json
@@ -25,7 +25,11 @@
     "Phrasing",
     "Palpable"
   ],
-  "permitted_content": [],
+  "permitted_content": [
+    {
+      "Category": "Transparent"
+    }
+  ],
   "permitted_parents": [
     {
       "Category": "Flow"

--- a/resources/parsed/elements/map.json
+++ b/resources/parsed/elements/map.json
@@ -19,7 +19,11 @@
     "Phrasing",
     "Palpable"
   ],
-  "permitted_content": [],
+  "permitted_content": [
+    {
+      "Category": "Transparent"
+    }
+  ],
   "permitted_parents": [
     {
       "Category": "Flow"

--- a/resources/parsed/elements/noscript.json
+++ b/resources/parsed/elements/noscript.json
@@ -17,9 +17,6 @@
       "Element": "Head"
     },
     {
-      "Element": "Head"
-    },
-    {
       "Element": "Link"
     },
     {
@@ -30,6 +27,9 @@
     },
     {
       "Element": "Text"
+    },
+    {
+      "Category": "Transparent"
     }
   ],
   "permitted_parents": [

--- a/resources/parsed/elements/object.json
+++ b/resources/parsed/elements/object.json
@@ -50,7 +50,11 @@
     "Embedded",
     "Palpable"
   ],
-  "permitted_content": [],
+  "permitted_content": [
+    {
+      "Category": "Transparent"
+    }
+  ],
   "permitted_parents": [
     {
       "Category": "Flow"

--- a/resources/parsed/elements/option.json
+++ b/resources/parsed/elements/option.json
@@ -38,9 +38,6 @@
       "Element": "DataList"
     },
     {
-      "Element": "DataList"
-    },
-    {
       "Element": "Text"
     }
   ],

--- a/resources/parsed/elements/slot.json
+++ b/resources/parsed/elements/slot.json
@@ -18,7 +18,11 @@
     "Flow",
     "Phrasing"
   ],
-  "permitted_content": [],
+  "permitted_content": [
+    {
+      "Category": "Transparent"
+    }
+  ],
   "permitted_parents": [
     {
       "Category": "Flow"

--- a/resources/parsed/elements/video.json
+++ b/resources/parsed/elements/video.json
@@ -89,7 +89,7 @@
       "Element": "TextTrack"
     },
     {
-      "Element": "TextTrack"
+      "Category": "Transparent"
     }
   ],
   "permitted_parents": [


### PR DESCRIPTION
Closes https://github.com/yoshuawuyts/html/issues/41, Closes https://github.com/yoshuawuyts/html/issues/43