### PR TITLE
add `xtask debug` tool

### DIFF
--- a/xtask/src/debug.rs
+++ b/xtask/src/debug.rs
@@ -1,0 +1,120 @@
+use async_std::fs;
+use async_std::path::PathBuf;
+use html_bindgen::merge::MergedElement;
+use html_bindgen::parse::ParsedElement;
+use html_bindgen::scrape::ScrapedElement;
+
+pub(crate) async fn debug(parent_name: String, child_name: String) -> crate::Result<()> {
+    debug_scraped_elements(&parent_name, &child_name).await?;
+    debug_parsed_elements(&parent_name, &child_name).await?;
+    debug_merged_element(&parent_name, &child_name).await?;
+    println!("=========== end ==========\n");
+
+    Ok(())
+}
+
+async fn debug_scraped_elements(parent_name: &str, child_name: &str) -> crate::Result<()> {
+    let mut parent = PathBuf::from("resources/scraped/elements");
+    let mut child = parent.clone();
+
+    parent.push(&parent_name);
+    parent.set_extension("json");
+    child.push(&child_name);
+    child.set_extension("json");
+
+    let parent = fs::read_to_string(parent).await?;
+    let child = fs::read_to_string(child).await?;
+
+    let parent: ScrapedElement = serde_json::from_str(&parent)?;
+    let child: ScrapedElement = serde_json::from_str(&child)?;
+
+    println!("===== SCRAPED ELEMENTS =====\n");
+
+    println!("[parent ({parent_name})] content model");
+    for item in parent.content_model {
+        print!("{item}, ")
+    }
+    println!("\n");
+
+    println!("[child ({child_name})] categories");
+    for item in child.categories {
+        print!("{item}, ")
+    }
+    println!("\n");
+
+    println!("[child ({child_name})] contexts");
+    for item in child.contexts {
+        print!("{item}, ")
+    }
+    println!("\n");
+
+    Ok(())
+}
+
+async fn debug_parsed_elements(parent_name: &str, child_name: &str) -> crate::Result<()> {
+    let mut parent = PathBuf::from("resources/parsed/elements");
+    let mut child = parent.clone();
+
+    parent.push(&parent_name);
+    parent.set_extension("json");
+    child.push(&child_name);
+    child.set_extension("json");
+
+    let parent = fs::read_to_string(parent).await?;
+    let child = fs::read_to_string(child).await?;
+    let parent: ParsedElement = serde_json::from_str(&parent)?;
+    let child: ParsedElement = serde_json::from_str(&child)?;
+
+    println!("===== PARSED ELEMENTS =====\n");
+
+    println!("[parent ({parent_name})] permitted content");
+    for content in parent.permitted_content {
+        print!("{content:?}, ")
+    }
+    println!("\n");
+
+    println!("[child ({child_name})] content categories");
+    for content in child.content_categories {
+        print!("{content:?}, ")
+    }
+    println!("\n");
+
+    println!("[child ({child_name})] permitted parents");
+    for content in child.permitted_parents {
+        print!("{content:?}, ")
+    }
+    println!("\n");
+
+    Ok(())
+}
+
+async fn debug_merged_element(parent_name: &str, child_name: &str) -> crate::Result<()> {
+    let mut parent = PathBuf::from("resources/merged/elements");
+    let mut child = parent.clone();
+
+    parent.push(&parent_name);
+    parent.set_extension("json");
+    child.push(&child_name);
+    child.set_extension("json");
+
+    let parent = fs::read_to_string(parent).await?;
+    let child = fs::read_to_string(child).await?;
+    let parent: MergedElement = serde_json::from_str(&parent)?;
+    let child: MergedElement = serde_json::from_str(&child)?;
+
+    println!("===== MERGED ELEMENTS =====\n");
+
+    println!("[parent ({parent_name})] permitted child elements");
+    for item in parent.permitted_child_elements {
+        print!("{item:?}, ")
+    }
+    println!("\n");
+
+    println!("[child ({child_name})] content categories");
+    for content in child.content_categories {
+        print!("{content:?}, ")
+    }
+    println!("\n");
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 use std::{env::current_dir, fs, path::PathBuf};
 use structopt::StructOpt;
 
+mod debug;
 mod fetch;
 mod generate;
 mod merge;
@@ -40,6 +41,8 @@ enum Opt {
     Merge,
     /// Generate Rust source code from the unified data
     Generate,
+    /// Debug the relationship between two nodes
+    Debug { parent: String, child: String },
 }
 
 #[async_std::main]
@@ -65,6 +68,7 @@ async fn main() -> Result<()> {
         Opt::NoFetch => {
             no_fetch().await?;
         }
+        Opt::Debug { parent, child } => debug::debug(parent, child).await?,
     }
     Ok(())
 }


### PR DESCRIPTION
This helps debug the reason why an element isn't a child element.

## Example output

```text
===== SCRAPED ELEMENTS =====

[parent (body)] content model
Flow content., 

[child (main)] categories
Flow content., Palpable content., 

[child (main)] contexts
Where flow content is expected, but only if it is a hierarchically correct
   main element., 

===== PARSED ELEMENTS =====

[parent (body)] permitted content
Category(Flow), 

[child (main)] content categories
Flow, Palpable, 

[child (main)] permitted parents
Element("Main"), Category(Flow), 

===== MERGED ELEMENTS =====

[parent (body)] permitted child elements
"Text", 

[child (main)] content categories
Flow, Palpable, 

=========== end ==========
```