### PR TITLE
fix `Display` impl, manually impl `Debug`

### DIFF
--- a/crates/html-bindgen/src/generate/sys/mod.rs
+++ b/crates/html-bindgen/src/generate/sys/mod.rs
@@ -247,7 +247,7 @@ fn generate_opening_tag(
     has_global_attrs: bool,
 ) -> String {
     let preamble = match tag_name {
-        "html" => "<!DOCTYPE html>\\n",
+        "html" => "<!DOCTYPE html>",
         _ => "",
     };
     let mut output = formatdoc!(

--- a/crates/html-sys/src/root/html.rs
+++ b/crates/html-sys/src/root/html.rs
@@ -10,7 +10,7 @@ pub struct Html {
 }
 impl crate::RenderElement for Html {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<!DOCTYPE html>\n<html")?;
+        write!(writer, "<!DOCTYPE html><html")?;
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
         write!(writer, ">")?;

--- a/crates/html/src/generated/a.rs
+++ b/crates/html/src/generated/a.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
     #[doc(alias = "a")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Anchor {
         sys: html_sys::text::Anchor,
         children: Vec<super::child::AnchorChild>,
@@ -438,9 +438,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Anchor {
+    impl std::fmt::Debug for Anchor {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Anchor {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -462,7 +472,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Anchor` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum AnchorChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1397,10 +1407,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for AnchorChild {
+    impl std::fmt::Debug for AnchorChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for AnchorChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/abbr.rs
+++ b/crates/html/src/generated/abbr.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)
     #[doc(alias = "abbr")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Abbreviation {
         sys: html_sys::text::Abbreviation,
         children: Vec<super::child::AbbreviationChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Abbreviation {
+    impl std::fmt::Debug for Abbreviation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Abbreviation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Abbreviation` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum AbbreviationChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -842,10 +852,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for AbbreviationChild {
+    impl std::fmt::Debug for AbbreviationChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for AbbreviationChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/address.rs
+++ b/crates/html/src/generated/address.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)
     #[doc(alias = "address")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Address {
         sys: html_sys::sections::Address,
         children: Vec<super::child::AddressChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Address {
+    impl std::fmt::Debug for Address {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Address {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Address` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum AddressChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1088,10 +1098,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for AddressChild {
+    impl std::fmt::Debug for AddressChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for AddressChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/area.rs
+++ b/crates/html/src/generated/area.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area)
     #[doc(alias = "area")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct ImageMapArea {
         sys: html_sys::embedded::ImageMapArea,
     }
@@ -429,9 +429,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for ImageMapArea {
+    impl std::fmt::Debug for ImageMapArea {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for ImageMapArea {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/article.rs
+++ b/crates/html/src/generated/article.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)
     #[doc(alias = "article")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Article {
         sys: html_sys::sections::Article,
         children: Vec<super::child::ArticleChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Article {
+    impl std::fmt::Debug for Article {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Article {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Article` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ArticleChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1089,10 +1099,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ArticleChild {
+    impl std::fmt::Debug for ArticleChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ArticleChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/aside.rs
+++ b/crates/html/src/generated/aside.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside)
     #[doc(alias = "aside")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Aside {
         sys: html_sys::sections::Aside,
         children: Vec<super::child::AsideChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Aside {
+    impl std::fmt::Debug for Aside {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Aside {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Aside` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum AsideChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1087,10 +1097,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for AsideChild {
+    impl std::fmt::Debug for AsideChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for AsideChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/audio.rs
+++ b/crates/html/src/generated/audio.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
     #[doc(alias = "audio")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Audio {
         sys: html_sys::embedded::Audio,
         children: Vec<super::child::AudioChild>,
@@ -427,9 +427,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Audio {
+    impl std::fmt::Debug for Audio {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Audio {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -452,7 +462,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Audio` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum AudioChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1385,10 +1395,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for AudioChild {
+    impl std::fmt::Debug for AudioChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for AudioChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/b.rs
+++ b/crates/html/src/generated/b.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b)
     #[doc(alias = "b")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Bold {
         sys: html_sys::text::Bold,
         children: Vec<super::child::BoldChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Bold {
+    impl std::fmt::Debug for Bold {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Bold {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Bold` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum BoldChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -839,10 +849,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for BoldChild {
+    impl std::fmt::Debug for BoldChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for BoldChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/base.rs
+++ b/crates/html/src/generated/base.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)
     #[doc(alias = "base")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Base {
         sys: html_sys::metadata::Base,
     }
@@ -352,9 +352,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Base {
+    impl std::fmt::Debug for Base {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Base {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/bdi.rs
+++ b/crates/html/src/generated/bdi.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi)
     #[doc(alias = "bdi")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct BidirectionalIsolate {
         sys: html_sys::text::BidirectionalIsolate,
         children: Vec<super::child::BidirectionalIsolateChild>,
@@ -352,9 +352,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for BidirectionalIsolate {
+    impl std::fmt::Debug for BidirectionalIsolate {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for BidirectionalIsolate {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -376,7 +386,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `BidirectionalIsolate` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum BidirectionalIsolateChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -880,10 +890,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for BidirectionalIsolateChild {
+    impl std::fmt::Debug for BidirectionalIsolateChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for BidirectionalIsolateChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/bdo.rs
+++ b/crates/html/src/generated/bdo.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo)
     #[doc(alias = "bdo")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct BidirectionalTextOverride {
         sys: html_sys::text::BidirectionalTextOverride,
         children: Vec<super::child::BidirectionalTextOverrideChild>,
@@ -352,9 +352,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for BidirectionalTextOverride {
+    impl std::fmt::Debug for BidirectionalTextOverride {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for BidirectionalTextOverride {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -376,7 +386,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `BidirectionalTextOverride` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum BidirectionalTextOverrideChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -896,10 +906,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for BidirectionalTextOverrideChild {
+    impl std::fmt::Debug for BidirectionalTextOverrideChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for BidirectionalTextOverrideChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/blockquote.rs
+++ b/crates/html/src/generated/blockquote.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)
     #[doc(alias = "blockquote")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct BlockQuote {
         sys: html_sys::text::BlockQuote,
         children: Vec<super::child::BlockQuoteChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for BlockQuote {
+    impl std::fmt::Debug for BlockQuote {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for BlockQuote {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -383,7 +393,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `BlockQuote` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum BlockQuoteChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1100,10 +1110,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for BlockQuoteChild {
+    impl std::fmt::Debug for BlockQuoteChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for BlockQuoteChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/body.rs
+++ b/crates/html/src/generated/body.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)
     #[doc(alias = "body")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Body {
         sys: html_sys::sections::Body,
         children: Vec<super::child::BodyChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Body {
+    impl std::fmt::Debug for Body {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Body {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Body` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum BodyChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1084,10 +1094,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for BodyChild {
+    impl std::fmt::Debug for BodyChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for BodyChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/br.rs
+++ b/crates/html/src/generated/br.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br)
     #[doc(alias = "br")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct LineBreak {
         sys: html_sys::text::LineBreak,
     }
@@ -330,9 +330,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for LineBreak {
+    impl std::fmt::Debug for LineBreak {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for LineBreak {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/button.rs
+++ b/crates/html/src/generated/button.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)
     #[doc(alias = "button")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Button {
         sys: html_sys::forms::Button,
         children: Vec<super::child::ButtonChild>,
@@ -476,9 +476,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Button {
+    impl std::fmt::Debug for Button {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Button {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -500,7 +510,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Button` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ButtonChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -968,10 +978,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ButtonChild {
+    impl std::fmt::Debug for ButtonChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ButtonChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/canvas.rs
+++ b/crates/html/src/generated/canvas.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas)
     #[doc(alias = "canvas")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Canvas {
         sys: html_sys::scripting::Canvas,
         children: Vec<super::child::CanvasChild>,
@@ -366,9 +366,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Canvas {
+    impl std::fmt::Debug for Canvas {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Canvas {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -390,7 +400,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Canvas` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum CanvasChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1325,10 +1335,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for CanvasChild {
+    impl std::fmt::Debug for CanvasChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for CanvasChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/caption.rs
+++ b/crates/html/src/generated/caption.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption)
     #[doc(alias = "caption")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Caption {
         sys: html_sys::tables::Caption,
         children: Vec<super::child::CaptionChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Caption {
+    impl std::fmt::Debug for Caption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Caption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Caption` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum CaptionChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1086,10 +1096,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for CaptionChild {
+    impl std::fmt::Debug for CaptionChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for CaptionChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/cite.rs
+++ b/crates/html/src/generated/cite.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)
     #[doc(alias = "cite")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Cite {
         sys: html_sys::text::Cite,
         children: Vec<super::child::CiteChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Cite {
+    impl std::fmt::Debug for Cite {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Cite {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Cite` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum CiteChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -839,10 +849,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for CiteChild {
+    impl std::fmt::Debug for CiteChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for CiteChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/code.rs
+++ b/crates/html/src/generated/code.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)
     #[doc(alias = "code")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Code {
         sys: html_sys::text::Code,
         children: Vec<super::child::CodeChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Code {
+    impl std::fmt::Debug for Code {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Code {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Code` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum CodeChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -839,10 +849,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for CodeChild {
+    impl std::fmt::Debug for CodeChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for CodeChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/col.rs
+++ b/crates/html/src/generated/col.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col)
     #[doc(alias = "col")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableColumn {
         sys: html_sys::tables::TableColumn,
     }
@@ -341,9 +341,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableColumn {
+    impl std::fmt::Debug for TableColumn {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableColumn {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/colgroup.rs
+++ b/crates/html/src/generated/colgroup.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup)
     #[doc(alias = "colgroup")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableColumnGroup {
         sys: html_sys::tables::TableColumnGroup,
         children: Vec<super::child::TableColumnGroupChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableColumnGroup {
+    impl std::fmt::Debug for TableColumnGroup {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableColumnGroup {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -381,7 +391,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableColumnGroup` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableColumnGroupChild {
         /// The TableColumn element
         TableColumn(crate::generated::all::TableColumn),
@@ -411,10 +421,18 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableColumnGroupChild {
+    impl std::fmt::Debug for TableColumnGroupChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableColumnGroupChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/data.rs
+++ b/crates/html/src/generated/data.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data)
     #[doc(alias = "data")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Data {
         sys: html_sys::text::Data,
         children: Vec<super::child::DataChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Data {
+    impl std::fmt::Debug for Data {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Data {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -384,7 +394,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Data` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DataChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -850,10 +860,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DataChild {
+    impl std::fmt::Debug for DataChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DataChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/datalist.rs
+++ b/crates/html/src/generated/datalist.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)
     #[doc(alias = "datalist")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct DataList {
         sys: html_sys::forms::DataList,
         children: Vec<super::child::DataListChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for DataList {
+    impl std::fmt::Debug for DataList {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for DataList {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `DataList` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DataListChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -848,10 +858,72 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DataListChild {
+    impl std::fmt::Debug for DataListChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DataListChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/dd.rs
+++ b/crates/html/src/generated/dd.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd)
     #[doc(alias = "dd")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct DescriptionDetails {
         sys: html_sys::text::DescriptionDetails,
         children: Vec<super::child::DescriptionDetailsChild>,
@@ -352,9 +352,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for DescriptionDetails {
+    impl std::fmt::Debug for DescriptionDetails {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for DescriptionDetails {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `DescriptionDetails` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DescriptionDetailsChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1129,10 +1139,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DescriptionDetailsChild {
+    impl std::fmt::Debug for DescriptionDetailsChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DescriptionDetailsChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/del.rs
+++ b/crates/html/src/generated/del.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
     #[doc(alias = "del")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct DeletedText {
         sys: html_sys::edits::DeletedText,
         children: Vec<super::child::DeletedTextChild>,
@@ -372,9 +372,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for DeletedText {
+    impl std::fmt::Debug for DeletedText {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for DeletedText {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -395,7 +405,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `DeletedText` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DeletedTextChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1335,10 +1345,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DeletedTextChild {
+    impl std::fmt::Debug for DeletedTextChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DeletedTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/details.rs
+++ b/crates/html/src/generated/details.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)
     #[doc(alias = "details")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Details {
         sys: html_sys::interactive::Details,
         children: Vec<super::child::DetailsChild>,
@@ -358,9 +358,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Details {
+    impl std::fmt::Debug for Details {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Details {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -381,7 +391,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Details` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DetailsChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1105,10 +1115,103 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DetailsChild {
+    impl std::fmt::Debug for DetailsChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DetailsChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/dfn.rs
+++ b/crates/html/src/generated/dfn.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn)
     #[doc(alias = "dfn")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Definition {
         sys: html_sys::text::Definition,
         children: Vec<super::child::DefinitionChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Definition {
+    impl std::fmt::Debug for Definition {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Definition {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Definition` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DefinitionChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DefinitionChild {
+    impl std::fmt::Debug for DefinitionChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DefinitionChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/dialog.rs
+++ b/crates/html/src/generated/dialog.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
     #[doc(alias = "dialog")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Dialog {
         sys: html_sys::interactive::Dialog,
         children: Vec<super::child::DialogChild>,
@@ -358,9 +358,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Dialog {
+    impl std::fmt::Debug for Dialog {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Dialog {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -379,7 +389,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Dialog` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DialogChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1095,10 +1105,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DialogChild {
+    impl std::fmt::Debug for DialogChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DialogChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/div.rs
+++ b/crates/html/src/generated/div.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div)
     #[doc(alias = "div")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Division {
         sys: html_sys::text::Division,
         children: Vec<super::child::DivisionChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Division {
+    impl std::fmt::Debug for Division {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Division {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Division` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DivisionChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1105,10 +1115,104 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DivisionChild {
+    impl std::fmt::Debug for DivisionChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DivisionChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/dl.rs
+++ b/crates/html/src/generated/dl.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl)
     #[doc(alias = "dl")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct DescriptionList {
         sys: html_sys::text::DescriptionList,
         children: Vec<super::child::DescriptionListChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for DescriptionList {
+    impl std::fmt::Debug for DescriptionList {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for DescriptionList {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `DescriptionList` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DescriptionListChild {
         /// The DescriptionDetails element
         DescriptionDetails(crate::generated::all::DescriptionDetails),
@@ -427,10 +437,21 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DescriptionListChild {
+    impl std::fmt::Debug for DescriptionListChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DescriptionListChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/dt.rs
+++ b/crates/html/src/generated/dt.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt)
     #[doc(alias = "dt")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct DescriptionTerm {
         sys: html_sys::text::DescriptionTerm,
         children: Vec<super::child::DescriptionTermChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for DescriptionTerm {
+    impl std::fmt::Debug for DescriptionTerm {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for DescriptionTerm {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `DescriptionTerm` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum DescriptionTermChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1102,10 +1112,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for DescriptionTermChild {
+    impl std::fmt::Debug for DescriptionTermChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for DescriptionTermChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/em.rs
+++ b/crates/html/src/generated/em.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)
     #[doc(alias = "em")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Emphasis {
         sys: html_sys::text::Emphasis,
         children: Vec<super::child::EmphasisChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Emphasis {
+    impl std::fmt::Debug for Emphasis {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Emphasis {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Emphasis` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum EmphasisChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for EmphasisChild {
+    impl std::fmt::Debug for EmphasisChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for EmphasisChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/embed.rs
+++ b/crates/html/src/generated/embed.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed)
     #[doc(alias = "embed")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Embed {
         sys: html_sys::embedded::Embed,
     }
@@ -374,9 +374,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Embed {
+    impl std::fmt::Debug for Embed {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Embed {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/fieldset.rs
+++ b/crates/html/src/generated/fieldset.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset)
     #[doc(alias = "fieldset")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Fieldset {
         sys: html_sys::forms::Fieldset,
         children: Vec<super::child::FieldsetChild>,
@@ -380,9 +380,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Fieldset {
+    impl std::fmt::Debug for Fieldset {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Fieldset {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -402,7 +412,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Fieldset` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum FieldsetChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1126,10 +1136,103 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for FieldsetChild {
+    impl std::fmt::Debug for FieldsetChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for FieldsetChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/figcaption.rs
+++ b/crates/html/src/generated/figcaption.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)
     #[doc(alias = "figcaption")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct FigureCaption {
         sys: html_sys::text::FigureCaption,
         children: Vec<super::child::FigureCaptionChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for FigureCaption {
+    impl std::fmt::Debug for FigureCaption {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for FigureCaption {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `FigureCaption` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum FigureCaptionChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1093,10 +1103,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for FigureCaptionChild {
+    impl std::fmt::Debug for FigureCaptionChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for FigureCaptionChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/figure.rs
+++ b/crates/html/src/generated/figure.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)
     #[doc(alias = "figure")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Figure {
         sys: html_sys::text::Figure,
         children: Vec<super::child::FigureChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Figure {
+    impl std::fmt::Debug for Figure {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Figure {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Figure` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum FigureChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1096,10 +1106,103 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for FigureChild {
+    impl std::fmt::Debug for FigureChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for FigureChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/footer.rs
+++ b/crates/html/src/generated/footer.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer)
     #[doc(alias = "footer")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Footer {
         sys: html_sys::sections::Footer,
         children: Vec<super::child::FooterChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Footer {
+    impl std::fmt::Debug for Footer {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Footer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Footer` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum FooterChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1088,10 +1098,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for FooterChild {
+    impl std::fmt::Debug for FooterChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for FooterChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/form.rs
+++ b/crates/html/src/generated/form.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
     #[doc(alias = "form")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Form {
         sys: html_sys::forms::Form,
         children: Vec<super::child::FormChild>,
@@ -435,9 +435,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Form {
+    impl std::fmt::Debug for Form {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Form {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -457,7 +467,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Form` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum FormChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1171,10 +1181,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for FormChild {
+    impl std::fmt::Debug for FormChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for FormChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/h1.rs
+++ b/crates/html/src/generated/h1.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1)
     #[doc(alias = "h1")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Heading1 {
         sys: html_sys::sections::Heading1,
         children: Vec<super::child::Heading1Child>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Heading1 {
+    impl std::fmt::Debug for Heading1 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading1 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Heading1` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum Heading1Child {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for Heading1Child {
+    impl std::fmt::Debug for Heading1Child {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading1Child {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/h2.rs
+++ b/crates/html/src/generated/h2.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2)
     #[doc(alias = "h2")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Heading2 {
         sys: html_sys::sections::Heading2,
         children: Vec<super::child::Heading2Child>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Heading2 {
+    impl std::fmt::Debug for Heading2 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading2 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Heading2` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum Heading2Child {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for Heading2Child {
+    impl std::fmt::Debug for Heading2Child {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading2Child {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/h3.rs
+++ b/crates/html/src/generated/h3.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3)
     #[doc(alias = "h3")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Heading3 {
         sys: html_sys::sections::Heading3,
         children: Vec<super::child::Heading3Child>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Heading3 {
+    impl std::fmt::Debug for Heading3 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading3 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Heading3` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum Heading3Child {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for Heading3Child {
+    impl std::fmt::Debug for Heading3Child {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading3Child {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/h4.rs
+++ b/crates/html/src/generated/h4.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4)
     #[doc(alias = "h4")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Heading4 {
         sys: html_sys::sections::Heading4,
         children: Vec<super::child::Heading4Child>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Heading4 {
+    impl std::fmt::Debug for Heading4 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading4 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Heading4` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum Heading4Child {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for Heading4Child {
+    impl std::fmt::Debug for Heading4Child {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading4Child {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/h5.rs
+++ b/crates/html/src/generated/h5.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5)
     #[doc(alias = "h5")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Heading5 {
         sys: html_sys::sections::Heading5,
         children: Vec<super::child::Heading5Child>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Heading5 {
+    impl std::fmt::Debug for Heading5 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading5 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Heading5` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum Heading5Child {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for Heading5Child {
+    impl std::fmt::Debug for Heading5Child {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading5Child {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/h6.rs
+++ b/crates/html/src/generated/h6.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6)
     #[doc(alias = "h6")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Heading6 {
         sys: html_sys::sections::Heading6,
         children: Vec<super::child::Heading6Child>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Heading6 {
+    impl std::fmt::Debug for Heading6 {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading6 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Heading6` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum Heading6Child {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for Heading6Child {
+    impl std::fmt::Debug for Heading6Child {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for Heading6Child {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/head.rs
+++ b/crates/html/src/generated/head.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)
     #[doc(alias = "head")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Head {
         sys: html_sys::metadata::Head,
         children: Vec<super::child::HeadChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Head {
+    impl std::fmt::Debug for Head {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Head {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Head` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum HeadChild {
         /// The Base element
         Base(crate::generated::all::Base),
@@ -447,10 +457,24 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for HeadChild {
+    impl std::fmt::Debug for HeadChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for HeadChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Base(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/header.rs
+++ b/crates/html/src/generated/header.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header)
     #[doc(alias = "header")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Header {
         sys: html_sys::sections::Header,
         children: Vec<super::child::HeaderChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Header {
+    impl std::fmt::Debug for Header {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Header {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Header` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum HeaderChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1088,10 +1098,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for HeaderChild {
+    impl std::fmt::Debug for HeaderChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for HeaderChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/hgroup.rs
+++ b/crates/html/src/generated/hgroup.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup)
     #[doc(alias = "hgroup")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct HeadingGroup {
         sys: html_sys::sections::HeadingGroup,
         children: Vec<super::child::HeadingGroupChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for HeadingGroup {
+    impl std::fmt::Debug for HeadingGroup {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for HeadingGroup {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `HeadingGroup` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum HeadingGroupChild {
         /// The Heading1 element
         Heading1(crate::generated::all::Heading1),
@@ -434,10 +444,22 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for HeadingGroupChild {
+    impl std::fmt::Debug for HeadingGroupChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for HeadingGroupChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/hr.rs
+++ b/crates/html/src/generated/hr.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)
     #[doc(alias = "hr")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct ThematicBreak {
         sys: html_sys::text::ThematicBreak,
     }
@@ -330,9 +330,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for ThematicBreak {
+    impl std::fmt::Debug for ThematicBreak {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for ThematicBreak {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/html.rs
+++ b/crates/html/src/generated/html.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)
     #[doc(alias = "html")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Html {
         sys: html_sys::root::Html,
         children: Vec<super::child::HtmlChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Html {
+    impl std::fmt::Debug for Html {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Html {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Html` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum HtmlChild {
         /// The Body element
         Body(crate::generated::all::Body),
@@ -399,10 +409,18 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for HtmlChild {
+    impl std::fmt::Debug for HtmlChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for HtmlChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/i.rs
+++ b/crates/html/src/generated/i.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i)
     #[doc(alias = "i")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Italic {
         sys: html_sys::text::Italic,
         children: Vec<super::child::ItalicChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Italic {
+    impl std::fmt::Debug for Italic {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Italic {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Italic` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ItalicChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ItalicChild {
+    impl std::fmt::Debug for ItalicChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ItalicChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/iframe.rs
+++ b/crates/html/src/generated/iframe.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)
     #[doc(alias = "iframe")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Iframe {
         sys: html_sys::embedded::Iframe,
     }
@@ -442,9 +442,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Iframe {
+    impl std::fmt::Debug for Iframe {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Iframe {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/img.rs
+++ b/crates/html/src/generated/img.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
     #[doc(alias = "img")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Image {
         sys: html_sys::embedded::Image,
     }
@@ -473,9 +473,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Image {
+    impl std::fmt::Debug for Image {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Image {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/input.rs
+++ b/crates/html/src/generated/input.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
     #[doc(alias = "input")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Input {
         sys: html_sys::forms::Input,
     }
@@ -682,9 +682,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Input {
+    impl std::fmt::Debug for Input {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Input {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/ins.rs
+++ b/crates/html/src/generated/ins.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
     #[doc(alias = "ins")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct InsertedText {
         sys: html_sys::edits::InsertedText,
         children: Vec<super::child::InsertedTextChild>,
@@ -372,9 +372,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for InsertedText {
+    impl std::fmt::Debug for InsertedText {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for InsertedText {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -395,7 +405,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `InsertedText` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum InsertedTextChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1336,10 +1346,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for InsertedTextChild {
+    impl std::fmt::Debug for InsertedTextChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for InsertedTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/kbd.rs
+++ b/crates/html/src/generated/kbd.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)
     #[doc(alias = "kbd")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct KeyboardInput {
         sys: html_sys::text::KeyboardInput,
         children: Vec<super::child::KeyboardInputChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for KeyboardInput {
+    impl std::fmt::Debug for KeyboardInput {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for KeyboardInput {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `KeyboardInput` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum KeyboardInputChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -844,10 +854,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for KeyboardInputChild {
+    impl std::fmt::Debug for KeyboardInputChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for KeyboardInputChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/label.rs
+++ b/crates/html/src/generated/label.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)
     #[doc(alias = "label")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Label {
         sys: html_sys::forms::Label,
         children: Vec<super::child::LabelChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Label {
+    impl std::fmt::Debug for Label {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Label {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -385,7 +395,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Label` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum LabelChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -851,10 +861,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for LabelChild {
+    impl std::fmt::Debug for LabelChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for LabelChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/legend.rs
+++ b/crates/html/src/generated/legend.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend)
     #[doc(alias = "legend")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Legend {
         sys: html_sys::forms::Legend,
         children: Vec<super::child::LegendChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Legend {
+    impl std::fmt::Debug for Legend {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Legend {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Legend` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum LegendChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -894,10 +904,78 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for LegendChild {
+    impl std::fmt::Debug for LegendChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for LegendChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/li.rs
+++ b/crates/html/src/generated/li.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li)
     #[doc(alias = "li")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct ListItem {
         sys: html_sys::text::ListItem,
         children: Vec<super::child::ListItemChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for ListItem {
+    impl std::fmt::Debug for ListItem {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for ListItem {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `ListItem` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ListItemChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1086,10 +1096,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ListItemChild {
+    impl std::fmt::Debug for ListItemChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ListItemChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/link.rs
+++ b/crates/html/src/generated/link.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)
     #[doc(alias = "link")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Link {
         sys: html_sys::metadata::Link,
     }
@@ -506,9 +506,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Link {
+    impl std::fmt::Debug for Link {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Link {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/main.rs
+++ b/crates/html/src/generated/main.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main)
     #[doc(alias = "main")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Main {
         sys: html_sys::text::Main,
         children: Vec<super::child::MainChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Main {
+    impl std::fmt::Debug for Main {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Main {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Main` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum MainChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1086,10 +1096,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for MainChild {
+    impl std::fmt::Debug for MainChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for MainChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/map.rs
+++ b/crates/html/src/generated/map.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map)
     #[doc(alias = "map")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct ImageMap {
         sys: html_sys::embedded::ImageMap,
         children: Vec<super::child::ImageMapChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for ImageMap {
+    impl std::fmt::Debug for ImageMap {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for ImageMap {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -384,7 +394,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `ImageMap` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ImageMapChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1320,10 +1330,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ImageMapChild {
+    impl std::fmt::Debug for ImageMapChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ImageMapChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/mark.rs
+++ b/crates/html/src/generated/mark.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)
     #[doc(alias = "mark")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct MarkText {
         sys: html_sys::text::MarkText,
         children: Vec<super::child::MarkTextChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for MarkText {
+    impl std::fmt::Debug for MarkText {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for MarkText {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `MarkText` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum MarkTextChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for MarkTextChild {
+    impl std::fmt::Debug for MarkTextChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for MarkTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/menu.rs
+++ b/crates/html/src/generated/menu.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu)
     #[doc(alias = "menu")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Menu {
         sys: html_sys::text::Menu,
         children: Vec<super::child::MenuChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Menu {
+    impl std::fmt::Debug for Menu {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Menu {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Menu` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum MenuChild {
         /// The ListItem element
         ListItem(crate::generated::all::ListItem),
@@ -409,10 +419,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for MenuChild {
+    impl std::fmt::Debug for MenuChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for MenuChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/meta.rs
+++ b/crates/html/src/generated/meta.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)
     #[doc(alias = "meta")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Meta {
         sys: html_sys::metadata::Meta,
     }
@@ -385,9 +385,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Meta {
+    impl std::fmt::Debug for Meta {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Meta {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/meter.rs
+++ b/crates/html/src/generated/meter.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter)
     #[doc(alias = "meter")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Meter {
         sys: html_sys::forms::Meter,
         children: Vec<super::child::MeterChild>,
@@ -398,9 +398,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Meter {
+    impl std::fmt::Debug for Meter {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Meter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -421,7 +431,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Meter` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum MeterChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -887,10 +897,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for MeterChild {
+    impl std::fmt::Debug for MeterChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for MeterChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/nav.rs
+++ b/crates/html/src/generated/nav.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav)
     #[doc(alias = "nav")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Navigation {
         sys: html_sys::sections::Navigation,
         children: Vec<super::child::NavigationChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Navigation {
+    impl std::fmt::Debug for Navigation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Navigation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Navigation` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum NavigationChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1090,10 +1100,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for NavigationChild {
+    impl std::fmt::Debug for NavigationChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for NavigationChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/noscript.rs
+++ b/crates/html/src/generated/noscript.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)
     #[doc(alias = "noscript")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct NoScript {
         sys: html_sys::scripting::NoScript,
         children: Vec<super::child::NoScriptChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for NoScript {
+    impl std::fmt::Debug for NoScript {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for NoScript {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `NoScript` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum NoScriptChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1309,10 +1319,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for NoScriptChild {
+    impl std::fmt::Debug for NoScriptChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for NoScriptChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/object.rs
+++ b/crates/html/src/generated/object.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object)
     #[doc(alias = "object")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Object {
         sys: html_sys::embedded::Object,
         children: Vec<super::child::ObjectChild>,
@@ -416,9 +416,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Object {
+    impl std::fmt::Debug for Object {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Object {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -440,7 +450,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Object` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ObjectChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1375,10 +1385,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ObjectChild {
+    impl std::fmt::Debug for ObjectChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ObjectChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/ol.rs
+++ b/crates/html/src/generated/ol.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol)
     #[doc(alias = "ol")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct OrderedList {
         sys: html_sys::text::OrderedList,
         children: Vec<super::child::OrderedListChild>,
@@ -383,9 +383,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for OrderedList {
+    impl std::fmt::Debug for OrderedList {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for OrderedList {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -405,7 +415,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `OrderedList` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum OrderedListChild {
         /// The ListItem element
         ListItem(crate::generated::all::ListItem),
@@ -442,10 +452,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for OrderedListChild {
+    impl std::fmt::Debug for OrderedListChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for OrderedListChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/optgroup.rs
+++ b/crates/html/src/generated/optgroup.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup)
     #[doc(alias = "optgroup")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct OptionGroup {
         sys: html_sys::forms::OptionGroup,
         children: Vec<super::child::OptionGroupChild>,
@@ -369,9 +369,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for OptionGroup {
+    impl std::fmt::Debug for OptionGroup {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for OptionGroup {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -389,7 +399,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `OptionGroup` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum OptionGroupChild {
         /// The Option element
         Option(crate::generated::all::Option),
@@ -426,10 +436,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for OptionGroupChild {
+    impl std::fmt::Debug for OptionGroupChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for OptionGroupChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Option(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/option.rs
+++ b/crates/html/src/generated/option.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option)
     #[doc(alias = "option")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Option {
         sys: html_sys::forms::Option,
         children: Vec<super::child::OptionChild>,
@@ -388,9 +388,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Option {
+    impl std::fmt::Debug for Option {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Option {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -408,7 +418,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Option` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum OptionChild {
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
@@ -439,10 +449,17 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for OptionChild {
+    impl std::fmt::Debug for OptionChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for OptionChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/output.rs
+++ b/crates/html/src/generated/output.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output)
     #[doc(alias = "output")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Output {
         sys: html_sys::forms::Output,
         children: Vec<super::child::OutputChild>,
@@ -383,9 +383,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Output {
+    impl std::fmt::Debug for Output {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Output {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -406,7 +416,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Output` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum OutputChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -874,10 +884,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for OutputChild {
+    impl std::fmt::Debug for OutputChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for OutputChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/p.rs
+++ b/crates/html/src/generated/p.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)
     #[doc(alias = "p")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Paragraph {
         sys: html_sys::text::Paragraph,
         children: Vec<super::child::ParagraphChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Paragraph {
+    impl std::fmt::Debug for Paragraph {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Paragraph {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Paragraph` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ParagraphChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -840,10 +850,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ParagraphChild {
+    impl std::fmt::Debug for ParagraphChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ParagraphChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/picture.rs
+++ b/crates/html/src/generated/picture.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
     #[doc(alias = "picture")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Picture {
         sys: html_sys::embedded::Picture,
         children: Vec<super::child::PictureChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Picture {
+    impl std::fmt::Debug for Picture {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Picture {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -374,7 +384,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Picture` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum PictureChild {
         /// The MediaSource element
         MediaSource(crate::generated::all::MediaSource),
@@ -411,10 +421,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for PictureChild {
+    impl std::fmt::Debug for PictureChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for PictureChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/pre.rs
+++ b/crates/html/src/generated/pre.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)
     #[doc(alias = "pre")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct PreformattedText {
         sys: html_sys::text::PreformattedText,
         children: Vec<super::child::PreformattedTextChild>,
@@ -345,9 +345,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for PreformattedText {
+    impl std::fmt::Debug for PreformattedText {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for PreformattedText {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -367,7 +377,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `PreformattedText` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum PreformattedTextChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -846,10 +856,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for PreformattedTextChild {
+    impl std::fmt::Debug for PreformattedTextChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for PreformattedTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/progress.rs
+++ b/crates/html/src/generated/progress.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress)
     #[doc(alias = "progress")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Progress {
         sys: html_sys::forms::Progress,
         children: Vec<super::child::ProgressChild>,
@@ -366,9 +366,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Progress {
+    impl std::fmt::Debug for Progress {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Progress {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -389,7 +399,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Progress` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ProgressChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -857,10 +867,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ProgressChild {
+    impl std::fmt::Debug for ProgressChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ProgressChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/q.rs
+++ b/crates/html/src/generated/q.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)
     #[doc(alias = "q")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Quotation {
         sys: html_sys::text::Quotation,
         children: Vec<super::child::QuotationChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Quotation {
+    impl std::fmt::Debug for Quotation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Quotation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -384,7 +394,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Quotation` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum QuotationChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -852,10 +862,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for QuotationChild {
+    impl std::fmt::Debug for QuotationChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for QuotationChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/rp.rs
+++ b/crates/html/src/generated/rp.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp)
     #[doc(alias = "rp")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct RubyFallbackParenthesis {
         sys: html_sys::text::RubyFallbackParenthesis,
     }
@@ -332,9 +332,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for RubyFallbackParenthesis {
+    impl std::fmt::Debug for RubyFallbackParenthesis {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for RubyFallbackParenthesis {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/rt.rs
+++ b/crates/html/src/generated/rt.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt)
     #[doc(alias = "rt")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct RubyText {
         sys: html_sys::text::RubyText,
         children: Vec<super::child::RubyTextChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for RubyText {
+    impl std::fmt::Debug for RubyText {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for RubyText {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `RubyText` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum RubyTextChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -838,10 +848,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for RubyTextChild {
+    impl std::fmt::Debug for RubyTextChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for RubyTextChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/ruby.rs
+++ b/crates/html/src/generated/ruby.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby)
     #[doc(alias = "ruby")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct RubyAnnotation {
         sys: html_sys::text::RubyAnnotation,
     }
@@ -332,9 +332,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for RubyAnnotation {
+    impl std::fmt::Debug for RubyAnnotation {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for RubyAnnotation {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/s.rs
+++ b/crates/html/src/generated/s.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)
     #[doc(alias = "s")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct StrikeThrough {
         sys: html_sys::text::StrikeThrough,
         children: Vec<super::child::StrikeThroughChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for StrikeThrough {
+    impl std::fmt::Debug for StrikeThrough {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for StrikeThrough {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `StrikeThrough` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum StrikeThroughChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -844,10 +854,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for StrikeThroughChild {
+    impl std::fmt::Debug for StrikeThroughChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for StrikeThroughChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/samp.rs
+++ b/crates/html/src/generated/samp.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)
     #[doc(alias = "samp")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct SampleOutput {
         sys: html_sys::text::SampleOutput,
         children: Vec<super::child::SampleOutputChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for SampleOutput {
+    impl std::fmt::Debug for SampleOutput {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for SampleOutput {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `SampleOutput` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SampleOutputChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -842,10 +852,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SampleOutputChild {
+    impl std::fmt::Debug for SampleOutputChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SampleOutputChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/script.rs
+++ b/crates/html/src/generated/script.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)
     #[doc(alias = "script")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Script {
         sys: html_sys::scripting::Script,
         children: Vec<super::child::ScriptChild>,
@@ -460,9 +460,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Script {
+    impl std::fmt::Debug for Script {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Script {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -484,7 +494,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Script` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum ScriptChild {
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
@@ -515,10 +525,17 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for ScriptChild {
+    impl std::fmt::Debug for ScriptChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for ScriptChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/search.rs
+++ b/crates/html/src/generated/search.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search)
     #[doc(alias = "search")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Search {
         sys: html_sys::text::Search,
         children: Vec<super::child::SearchChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Search {
+    impl std::fmt::Debug for Search {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Search {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Search` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SearchChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1088,10 +1098,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SearchChild {
+    impl std::fmt::Debug for SearchChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SearchChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/section.rs
+++ b/crates/html/src/generated/section.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)
     #[doc(alias = "section")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Section {
         sys: html_sys::sections::Section,
         children: Vec<super::child::SectionChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Section {
+    impl std::fmt::Debug for Section {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Section {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Section` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SectionChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1089,10 +1099,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SectionChild {
+    impl std::fmt::Debug for SectionChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SectionChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/select.rs
+++ b/crates/html/src/generated/select.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
     #[doc(alias = "select")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Select {
         sys: html_sys::forms::Select,
         children: Vec<super::child::SelectChild>,
@@ -415,9 +415,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Select {
+    impl std::fmt::Debug for Select {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Select {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -439,7 +449,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Select` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SelectChild {
         /// The Option element
         Option(crate::generated::all::Option),
@@ -492,10 +502,21 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SelectChild {
+    impl std::fmt::Debug for SelectChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SelectChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/slot.rs
+++ b/crates/html/src/generated/slot.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)
     #[doc(alias = "slot")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Slot {
         sys: html_sys::scripting::Slot,
         children: Vec<super::child::SlotChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Slot {
+    impl std::fmt::Debug for Slot {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Slot {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -383,7 +393,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Slot` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SlotChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1316,10 +1326,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SlotChild {
+    impl std::fmt::Debug for SlotChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SlotChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/small.rs
+++ b/crates/html/src/generated/small.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)
     #[doc(alias = "small")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct SideComment {
         sys: html_sys::text::SideComment,
         children: Vec<super::child::SideCommentChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for SideComment {
+    impl std::fmt::Debug for SideComment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for SideComment {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `SideComment` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SideCommentChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SideCommentChild {
+    impl std::fmt::Debug for SideCommentChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SideCommentChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/source.rs
+++ b/crates/html/src/generated/source.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
     #[doc(alias = "source")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct MediaSource {
         sys: html_sys::embedded::MediaSource,
     }
@@ -352,9 +352,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for MediaSource {
+    impl std::fmt::Debug for MediaSource {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for MediaSource {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/span.rs
+++ b/crates/html/src/generated/span.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
     #[doc(alias = "span")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Span {
         sys: html_sys::text::Span,
         children: Vec<super::child::SpanChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Span {
+    impl std::fmt::Debug for Span {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Span {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Span` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SpanChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -839,10 +849,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SpanChild {
+    impl std::fmt::Debug for SpanChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SpanChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/strong.rs
+++ b/crates/html/src/generated/strong.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)
     #[doc(alias = "strong")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Strong {
         sys: html_sys::text::Strong,
         children: Vec<super::child::StrongChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Strong {
+    impl std::fmt::Debug for Strong {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Strong {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Strong` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum StrongChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for StrongChild {
+    impl std::fmt::Debug for StrongChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for StrongChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/style.rs
+++ b/crates/html/src/generated/style.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)
     #[doc(alias = "style")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Style {
         sys: html_sys::metadata::Style,
         children: Vec<super::child::StyleChild>,
@@ -372,9 +372,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Style {
+    impl std::fmt::Debug for Style {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Style {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -393,7 +403,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Style` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum StyleChild {
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
@@ -424,10 +434,17 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for StyleChild {
+    impl std::fmt::Debug for StyleChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for StyleChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/sub.rs
+++ b/crates/html/src/generated/sub.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)
     #[doc(alias = "sub")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct SubScript {
         sys: html_sys::text::SubScript,
         children: Vec<super::child::SubScriptChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for SubScript {
+    impl std::fmt::Debug for SubScript {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for SubScript {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `SubScript` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SubScriptChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SubScriptChild {
+    impl std::fmt::Debug for SubScriptChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SubScriptChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/summary.rs
+++ b/crates/html/src/generated/summary.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary)
     #[doc(alias = "summary")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Summary {
         sys: html_sys::interactive::Summary,
         children: Vec<super::child::SummaryChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Summary {
+    impl std::fmt::Debug for Summary {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Summary {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Summary` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SummaryChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -894,10 +904,78 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SummaryChild {
+    impl std::fmt::Debug for SummaryChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SummaryChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/sup.rs
+++ b/crates/html/src/generated/sup.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)
     #[doc(alias = "sup")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct SuperScript {
         sys: html_sys::text::SuperScript,
         children: Vec<super::child::SuperScriptChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for SuperScript {
+    impl std::fmt::Debug for SuperScript {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for SuperScript {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `SuperScript` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum SuperScriptChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for SuperScriptChild {
+    impl std::fmt::Debug for SuperScriptChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for SuperScriptChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/table.rs
+++ b/crates/html/src/generated/table.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)
     #[doc(alias = "table")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Table {
         sys: html_sys::tables::Table,
         children: Vec<super::child::TableChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Table {
+    impl std::fmt::Debug for Table {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Table {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Table` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableChild {
         /// The Caption element
         Caption(crate::generated::all::Caption),
@@ -449,10 +459,24 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableChild {
+    impl std::fmt::Debug for TableChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/tbody.rs
+++ b/crates/html/src/generated/tbody.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody)
     #[doc(alias = "tbody")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableBody {
         sys: html_sys::tables::TableBody,
         children: Vec<super::child::TableBodyChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableBody {
+    impl std::fmt::Debug for TableBody {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableBody {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableBody` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableBodyChild {
         /// The Script element
         Script(crate::generated::all::Script),
@@ -407,10 +417,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableBodyChild {
+    impl std::fmt::Debug for TableBodyChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableBodyChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Script(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/td.rs
+++ b/crates/html/src/generated/td.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)
     #[doc(alias = "td")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableCell {
         sys: html_sys::tables::TableCell,
         children: Vec<super::child::TableCellChild>,
@@ -383,9 +383,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableCell {
+    impl std::fmt::Debug for TableCell {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableCell {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -403,7 +413,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableCell` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableCellChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1119,10 +1129,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableCellChild {
+    impl std::fmt::Debug for TableCellChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableCellChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/template.rs
+++ b/crates/html/src/generated/template.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)
     #[doc(alias = "template")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Template {
         sys: html_sys::scripting::Template,
     }
@@ -332,9 +332,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Template {
+    impl std::fmt::Debug for Template {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Template {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/textarea.rs
+++ b/crates/html/src/generated/textarea.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
     #[doc(alias = "textarea")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TextArea {
         sys: html_sys::forms::TextArea,
     }
@@ -454,9 +454,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TextArea {
+    impl std::fmt::Debug for TextArea {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TextArea {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/tfoot.rs
+++ b/crates/html/src/generated/tfoot.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot)
     #[doc(alias = "tfoot")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableFoot {
         sys: html_sys::tables::TableFoot,
         children: Vec<super::child::TableFootChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableFoot {
+    impl std::fmt::Debug for TableFoot {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableFoot {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableFoot` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableFootChild {
         /// The Script element
         Script(crate::generated::all::Script),
@@ -407,10 +417,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableFootChild {
+    impl std::fmt::Debug for TableFootChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableFootChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Script(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/th.rs
+++ b/crates/html/src/generated/th.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)
     #[doc(alias = "th")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableHeader {
         sys: html_sys::tables::TableHeader,
         children: Vec<super::child::TableHeaderChild>,
@@ -405,9 +405,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableHeader {
+    impl std::fmt::Debug for TableHeader {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableHeader {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -425,7 +435,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableHeader` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableHeaderChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1143,10 +1153,102 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableHeaderChild {
+    impl std::fmt::Debug for TableHeaderChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableHeaderChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/thead.rs
+++ b/crates/html/src/generated/thead.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead)
     #[doc(alias = "thead")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableHead {
         sys: html_sys::tables::TableHead,
         children: Vec<super::child::TableHeadChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableHead {
+    impl std::fmt::Debug for TableHead {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableHead {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableHead` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableHeadChild {
         /// The Script element
         Script(crate::generated::all::Script),
@@ -407,10 +417,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableHeadChild {
+    impl std::fmt::Debug for TableHeadChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableHeadChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Script(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/time.rs
+++ b/crates/html/src/generated/time.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
     #[doc(alias = "time")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Time {
         sys: html_sys::text::Time,
         children: Vec<super::child::TimeChild>,
@@ -361,9 +361,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Time {
+    impl std::fmt::Debug for Time {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Time {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -384,7 +394,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Time` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TimeChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -850,10 +860,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TimeChild {
+    impl std::fmt::Debug for TimeChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TimeChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/title.rs
+++ b/crates/html/src/generated/title.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
     #[doc(alias = "title")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Title {
         sys: html_sys::metadata::Title,
         children: Vec<super::child::TitleChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Title {
+    impl std::fmt::Debug for Title {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Title {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -371,7 +381,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Title` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TitleChild {
         /// The Text element
         Text(std::borrow::Cow<'static, str>),
@@ -402,10 +412,17 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TitleChild {
+    impl std::fmt::Debug for TitleChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TitleChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Text(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/tr.rs
+++ b/crates/html/src/generated/tr.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr)
     #[doc(alias = "tr")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TableRow {
         sys: html_sys::tables::TableRow,
         children: Vec<super::child::TableRowChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TableRow {
+    impl std::fmt::Debug for TableRow {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TableRow {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -370,7 +380,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `TableRow` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum TableRowChild {
         /// The Script element
         Script(crate::generated::all::Script),
@@ -415,10 +425,20 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for TableRowChild {
+    impl std::fmt::Debug for TableRowChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for TableRowChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Script(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/track.rs
+++ b/crates/html/src/generated/track.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track)
     #[doc(alias = "track")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct TextTrack {
         sys: html_sys::embedded::TextTrack,
     }
@@ -382,9 +382,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for TextTrack {
+    impl std::fmt::Debug for TextTrack {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for TextTrack {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/src/generated/u.rs
+++ b/crates/html/src/generated/u.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u)
     #[doc(alias = "u")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Underline {
         sys: html_sys::text::Underline,
         children: Vec<super::child::UnderlineChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Underline {
+    impl std::fmt::Debug for Underline {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Underline {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Underline` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum UnderlineChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for UnderlineChild {
+    impl std::fmt::Debug for UnderlineChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for UnderlineChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/ul.rs
+++ b/crates/html/src/generated/ul.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul)
     #[doc(alias = "ul")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct UnorderedList {
         sys: html_sys::text::UnorderedList,
         children: Vec<super::child::UnorderedListChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for UnorderedList {
+    impl std::fmt::Debug for UnorderedList {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for UnorderedList {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -372,7 +382,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `UnorderedList` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum UnorderedListChild {
         /// The ListItem element
         ListItem(crate::generated::all::ListItem),
@@ -409,10 +419,19 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for UnorderedListChild {
+    impl std::fmt::Debug for UnorderedListChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for UnorderedListChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/var.rs
+++ b/crates/html/src/generated/var.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)
     #[doc(alias = "var")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Variable {
         sys: html_sys::text::Variable,
         children: Vec<super::child::VariableChild>,
@@ -350,9 +350,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Variable {
+    impl std::fmt::Debug for Variable {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Variable {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -373,7 +383,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Variable` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum VariableChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -841,10 +851,71 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for VariableChild {
+    impl std::fmt::Debug for VariableChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for VariableChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/video.rs
+++ b/crates/html/src/generated/video.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)
     #[doc(alias = "video")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct Video {
         sys: html_sys::embedded::Video,
         children: Vec<super::child::VideoChild>,
@@ -462,9 +462,19 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for Video {
+    impl std::fmt::Debug for Video {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for Video {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            for el in &self.children {
+                write!(f, "{el}")?;
+            }
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }
@@ -487,7 +497,7 @@ pub mod element {
 }
 pub mod child {
     /// The permitted child items for the `Video` element
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(PartialEq, Clone)]
     pub enum VideoChild {
         /// The Abbreviation element
         Abbreviation(crate::generated::all::Abbreviation),
@@ -1420,10 +1430,129 @@ pub mod child {
             }
         }
     }
-    impl std::fmt::Display for VideoChild {
+    impl std::fmt::Debug for VideoChild {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
             Ok(())
+        }
+    }
+    impl std::fmt::Display for VideoChild {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Abbreviation(el) => write!(f, "{el}"),
+                Self::Address(el) => write!(f, "{el}"),
+                Self::Anchor(el) => write!(f, "{el}"),
+                Self::Article(el) => write!(f, "{el}"),
+                Self::Aside(el) => write!(f, "{el}"),
+                Self::Audio(el) => write!(f, "{el}"),
+                Self::Base(el) => write!(f, "{el}"),
+                Self::BidirectionalIsolate(el) => write!(f, "{el}"),
+                Self::BidirectionalTextOverride(el) => write!(f, "{el}"),
+                Self::BlockQuote(el) => write!(f, "{el}"),
+                Self::Body(el) => write!(f, "{el}"),
+                Self::Bold(el) => write!(f, "{el}"),
+                Self::Button(el) => write!(f, "{el}"),
+                Self::Canvas(el) => write!(f, "{el}"),
+                Self::Caption(el) => write!(f, "{el}"),
+                Self::Cite(el) => write!(f, "{el}"),
+                Self::Code(el) => write!(f, "{el}"),
+                Self::Data(el) => write!(f, "{el}"),
+                Self::DataList(el) => write!(f, "{el}"),
+                Self::Definition(el) => write!(f, "{el}"),
+                Self::DeletedText(el) => write!(f, "{el}"),
+                Self::DescriptionDetails(el) => write!(f, "{el}"),
+                Self::DescriptionList(el) => write!(f, "{el}"),
+                Self::DescriptionTerm(el) => write!(f, "{el}"),
+                Self::Details(el) => write!(f, "{el}"),
+                Self::Dialog(el) => write!(f, "{el}"),
+                Self::Division(el) => write!(f, "{el}"),
+                Self::Embed(el) => write!(f, "{el}"),
+                Self::Emphasis(el) => write!(f, "{el}"),
+                Self::Fieldset(el) => write!(f, "{el}"),
+                Self::Figure(el) => write!(f, "{el}"),
+                Self::FigureCaption(el) => write!(f, "{el}"),
+                Self::Footer(el) => write!(f, "{el}"),
+                Self::Form(el) => write!(f, "{el}"),
+                Self::Head(el) => write!(f, "{el}"),
+                Self::Header(el) => write!(f, "{el}"),
+                Self::Heading1(el) => write!(f, "{el}"),
+                Self::Heading2(el) => write!(f, "{el}"),
+                Self::Heading3(el) => write!(f, "{el}"),
+                Self::Heading4(el) => write!(f, "{el}"),
+                Self::Heading5(el) => write!(f, "{el}"),
+                Self::Heading6(el) => write!(f, "{el}"),
+                Self::HeadingGroup(el) => write!(f, "{el}"),
+                Self::Html(el) => write!(f, "{el}"),
+                Self::Iframe(el) => write!(f, "{el}"),
+                Self::Image(el) => write!(f, "{el}"),
+                Self::ImageMap(el) => write!(f, "{el}"),
+                Self::ImageMapArea(el) => write!(f, "{el}"),
+                Self::Input(el) => write!(f, "{el}"),
+                Self::InsertedText(el) => write!(f, "{el}"),
+                Self::Italic(el) => write!(f, "{el}"),
+                Self::KeyboardInput(el) => write!(f, "{el}"),
+                Self::Label(el) => write!(f, "{el}"),
+                Self::Legend(el) => write!(f, "{el}"),
+                Self::LineBreak(el) => write!(f, "{el}"),
+                Self::LineBreakOpportunity(el) => write!(f, "{el}"),
+                Self::Link(el) => write!(f, "{el}"),
+                Self::ListItem(el) => write!(f, "{el}"),
+                Self::Main(el) => write!(f, "{el}"),
+                Self::MarkText(el) => write!(f, "{el}"),
+                Self::MediaSource(el) => write!(f, "{el}"),
+                Self::Menu(el) => write!(f, "{el}"),
+                Self::Meta(el) => write!(f, "{el}"),
+                Self::Meter(el) => write!(f, "{el}"),
+                Self::Navigation(el) => write!(f, "{el}"),
+                Self::NoScript(el) => write!(f, "{el}"),
+                Self::Object(el) => write!(f, "{el}"),
+                Self::Option(el) => write!(f, "{el}"),
+                Self::OptionGroup(el) => write!(f, "{el}"),
+                Self::OrderedList(el) => write!(f, "{el}"),
+                Self::Output(el) => write!(f, "{el}"),
+                Self::Paragraph(el) => write!(f, "{el}"),
+                Self::Picture(el) => write!(f, "{el}"),
+                Self::PreformattedText(el) => write!(f, "{el}"),
+                Self::Progress(el) => write!(f, "{el}"),
+                Self::Quotation(el) => write!(f, "{el}"),
+                Self::RubyAnnotation(el) => write!(f, "{el}"),
+                Self::RubyFallbackParenthesis(el) => write!(f, "{el}"),
+                Self::RubyText(el) => write!(f, "{el}"),
+                Self::SampleOutput(el) => write!(f, "{el}"),
+                Self::Script(el) => write!(f, "{el}"),
+                Self::Search(el) => write!(f, "{el}"),
+                Self::Section(el) => write!(f, "{el}"),
+                Self::Select(el) => write!(f, "{el}"),
+                Self::SideComment(el) => write!(f, "{el}"),
+                Self::Slot(el) => write!(f, "{el}"),
+                Self::Span(el) => write!(f, "{el}"),
+                Self::StrikeThrough(el) => write!(f, "{el}"),
+                Self::Strong(el) => write!(f, "{el}"),
+                Self::Style(el) => write!(f, "{el}"),
+                Self::SubScript(el) => write!(f, "{el}"),
+                Self::Summary(el) => write!(f, "{el}"),
+                Self::SuperScript(el) => write!(f, "{el}"),
+                Self::Table(el) => write!(f, "{el}"),
+                Self::TableBody(el) => write!(f, "{el}"),
+                Self::TableCell(el) => write!(f, "{el}"),
+                Self::TableColumn(el) => write!(f, "{el}"),
+                Self::TableColumnGroup(el) => write!(f, "{el}"),
+                Self::TableFoot(el) => write!(f, "{el}"),
+                Self::TableHead(el) => write!(f, "{el}"),
+                Self::TableHeader(el) => write!(f, "{el}"),
+                Self::TableRow(el) => write!(f, "{el}"),
+                Self::Template(el) => write!(f, "{el}"),
+                Self::Text(el) => write!(f, "{el}"),
+                Self::TextArea(el) => write!(f, "{el}"),
+                Self::TextTrack(el) => write!(f, "{el}"),
+                Self::ThematicBreak(el) => write!(f, "{el}"),
+                Self::Time(el) => write!(f, "{el}"),
+                Self::Title(el) => write!(f, "{el}"),
+                Self::Underline(el) => write!(f, "{el}"),
+                Self::UnorderedList(el) => write!(f, "{el}"),
+                Self::Variable(el) => write!(f, "{el}"),
+                Self::Video(el) => write!(f, "{el}"),
+            }
         }
     }
 }

--- a/crates/html/src/generated/wbr.rs
+++ b/crates/html/src/generated/wbr.rs
@@ -4,7 +4,7 @@ pub mod element {
     /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)
     #[doc(alias = "wbr")]
     #[non_exhaustive]
-    #[derive(Debug, PartialEq, Clone, Default)]
+    #[derive(PartialEq, Clone, Default)]
     pub struct LineBreakOpportunity {
         sys: html_sys::text::LineBreakOpportunity,
     }
@@ -330,9 +330,16 @@ pub mod element {
             Ok(())
         }
     }
-    impl std::fmt::Display for LineBreakOpportunity {
+    impl std::fmt::Debug for LineBreakOpportunity {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             crate::Render::render(self, f, 0)?;
+            Ok(())
+        }
+    }
+    impl std::fmt::Display for LineBreakOpportunity {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            html_sys::RenderElement::write_opening_tag(&self.sys, f)?;
+            html_sys::RenderElement::write_closing_tag(&self.sys, f)?;
             Ok(())
         }
     }

--- a/crates/html/tests/extend.rs
+++ b/crates/html/tests/extend.rs
@@ -11,11 +11,10 @@ fn push() {
         .build();
 
     assert_eq!(
-        tree.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"
-        <!DOCTYPE html>
-        <html>
+        <!DOCTYPE html><html>
             <head>
                 <meta name="example">
             </head>
@@ -36,11 +35,10 @@ fn extend() {
         .build();
 
     assert_eq!(
-        tree.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"
-        <!DOCTYPE html>
-        <html>
+        <!DOCTYPE html><html>
             <head>
                 <meta name="first">
                 <meta name="second">

--- a/crates/html/tests/html-doc.rs
+++ b/crates/html/tests/html-doc.rs
@@ -15,11 +15,10 @@ fn html_doc() {
         .build();
 
     assert_eq!(
-        tree.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"
-        <!DOCTYPE html>
-        <html lang="en">
+        <!DOCTYPE html><html lang="en">
             <head>
                 <meta charset="utf-8">
                 <title>
@@ -31,5 +30,10 @@ fn html_doc() {
             </body>
         </html>"#
         )
+    );
+
+    assert_eq!(
+        tree.to_string(),
+        r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>My site</title></head><body>Hello, world!</body></html>"#
     )
 }

--- a/crates/html/tests/pre.rs
+++ b/crates/html/tests/pre.rs
@@ -23,12 +23,12 @@ fn test_pre() {
 
 #[test]
 fn regular_pre() {
-    let el = Body::builder()
+    let tree = Body::builder()
         .preformatted_text(|pre| pre.text("hello"))
         .build();
 
     assert_eq!(
-        el.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"<body>
                    <pre>hello</pre>

--- a/crates/html/tests/test.rs
+++ b/crates/html/tests/test.rs
@@ -23,12 +23,7 @@ fn smoke() {
     let s = button.to_string();
     assert_eq!(
         s,
-        indoc::indoc!(
-            r#"
-            <button disabled name="testbutton">
-                hello world
-            </button>"#
-        )
+        r#"<button disabled name="testbutton">hello world</button>"#
     );
 }
 
@@ -39,7 +34,7 @@ fn builder() {
         .list_item(|li| li.text("world").class("pigeon"))
         .build();
     assert_eq!(
-        tree.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"
             <ol>
@@ -62,7 +57,7 @@ fn looper() {
     }
     let tree = ol.build();
     assert_eq!(
-        tree.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"
         <ol>
@@ -85,7 +80,7 @@ fn data_attrs() {
     }
     let tree = ol.build();
     assert_eq!(
-        tree.to_string(),
+        format!("{tree:?}"),
         indoc!(
             r#"
             <ol>


### PR DESCRIPTION
Fixes #60. The `Display` impl on HTML elements now no longer auto-indents. Instead you can get a pretty-printed - but possibly broken - output by using the new `Debug` impl instead.

This should strike a balance between the two. Display should now work as intended, while if you want to figure out what exactly is happening you can use the `Debug` impl which matches what we were doing before this patch.

I hope this can fix *all* rendering cases by just not bothering with pretty-printing. Because I'd very much like for this crate to become something people can depend on. Thanks!