### PR TITLE
Add conditional html attributes

### DIFF
--- a/crates/html-bindgen/src/parse/elements/mod.rs
+++ b/crates/html-bindgen/src/parse/elements/mod.rs
@@ -167,10 +167,18 @@ fn parse_attrs(content_attributes: Vec<String>) -> (bool, Vec<Attribute>) {
         let name = iter.next().unwrap().trim().to_owned();
         let description = iter.next().unwrap().trim().to_owned();
 
-        // we skip over all the conditional comments for now.
-        if name.contains(' ') {
-            continue;
-        }
+        // Add conditional attributes and document their conditionality.
+        // This probably won't be the final way this is done as this loses some of the type-safety guarantees.
+        let (name, description) = match name.as_str() {
+            "If the element is not a child of an ul or menu element: value" => {
+                ("value".to_owned(), format!("{description}. Only if the element is not a child of an `ul` or `menu` element."))
+            }
+            _ => if let Some((name, condition)) = name.split_once(" ") {
+                (name.to_owned(), format!("{description} {condition}"))
+            } else {
+                (name, description)
+            }
+        };
 
         // Rename attributes which are labeled after keywords
         let field_name = super::normalize_field_name(&name);

--- a/crates/html-sys/src/embedded/source.rs
+++ b/crates/html-sys/src/embedded/source.rs
@@ -11,6 +11,16 @@ pub struct MediaSource {
     pub type_: std::option::Option<std::borrow::Cow<'static, str>>,
     /// Applicable media
     pub media: std::option::Option<std::borrow::Cow<'static, str>>,
+    /// Address of the resource (in audio or video)
+    pub src: std::option::Option<std::borrow::Cow<'static, str>>,
+    /// Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (in picture)
+    pub srcset: std::option::Option<std::borrow::Cow<'static, str>>,
+    /// Image sizes for different page layouts (in picture)
+    pub sizes: std::option::Option<std::borrow::Cow<'static, str>>,
+    /// Horizontal dimension (in picture)
+    pub width: std::option::Option<i64>,
+    /// Vertical dimension (in picture)
+    pub height: std::option::Option<i64>,
 }
 impl crate::RenderElement for MediaSource {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
@@ -20,6 +30,21 @@ impl crate::RenderElement for MediaSource {
         }
         if let Some(field) = self.media.as_ref() {
             write!(writer, r#" media="{field}""#)?;
+        }
+        if let Some(field) = self.src.as_ref() {
+            write!(writer, r#" src="{field}""#)?;
+        }
+        if let Some(field) = self.srcset.as_ref() {
+            write!(writer, r#" srcset="{field}""#)?;
+        }
+        if let Some(field) = self.sizes.as_ref() {
+            write!(writer, r#" sizes="{field}""#)?;
+        }
+        if let Some(field) = self.width.as_ref() {
+            write!(writer, r#" width="{field}""#)?;
+        }
+        if let Some(field) = self.height.as_ref() {
+            write!(writer, r#" height="{field}""#)?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/text/li.rs
+++ b/crates/html-sys/src/text/li.rs
@@ -7,6 +7,8 @@
 pub struct ListItem {
     pub data_map: crate::DataMap,
     global_attrs: crate::GlobalAttributes,
+    /// Ordinal value of the list item. Only if the element is not a child of an `ul` or `menu` element.
+    pub value: std::option::Option<std::borrow::Cow<'static, str>>,
     /// Describes the role(s) the current element plays in the context of the document.
     pub role: std::option::Option<std::borrow::Cow<'static, str>>,
     /// Identifies the currently active element when DOM focus is on a composite widget, combobox, textbox, group, or application.
@@ -123,6 +125,9 @@ pub struct ListItem {
 impl crate::RenderElement for ListItem {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
         write!(writer, "<li")?;
+        if let Some(field) = self.value.as_ref() {
+            write!(writer, r#" value="{field}""#)?;
+        }
         if let Some(field) = self.role.as_ref() {
             write!(writer, r#" role="{field}""#)?;
         }

--- a/crates/html/src/generated/li.rs
+++ b/crates/html/src/generated/li.rs
@@ -26,6 +26,17 @@ pub mod element {
         }
     }
     impl ListItem {
+        /// Get the value of the `value` attribute
+        pub fn value(&self) -> std::option::Option<&str> {
+            self.sys.value.as_deref()
+        }
+        /// Set the value of the `value` attribute
+        pub fn set_value(
+            &mut self,
+            value: std::option::Option<impl Into<std::borrow::Cow<'static, str>>>,
+        ) {
+            self.sys.value = value.map(|v| v.into());
+        }
         /// Get the value of the `role` attribute
         pub fn role(&self) -> std::option::Option<&str> {
             self.sys.role.as_deref()
@@ -3034,6 +3045,14 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Set the value of the `value` attribute
+        pub fn value(
+            &mut self,
+            value: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            self.element.set_value(Some(value.into()));
             self
         }
         /// Set the value of the `role` attribute

--- a/crates/html/src/generated/source.rs
+++ b/crates/html/src/generated/source.rs
@@ -47,6 +47,55 @@ pub mod element {
         ) {
             self.sys.media = value.map(|v| v.into());
         }
+        /// Get the value of the `src` attribute
+        pub fn src(&self) -> std::option::Option<&str> {
+            self.sys.src.as_deref()
+        }
+        /// Set the value of the `src` attribute
+        pub fn set_src(
+            &mut self,
+            value: std::option::Option<impl Into<std::borrow::Cow<'static, str>>>,
+        ) {
+            self.sys.src = value.map(|v| v.into());
+        }
+        /// Get the value of the `srcset` attribute
+        pub fn srcset(&self) -> std::option::Option<&str> {
+            self.sys.srcset.as_deref()
+        }
+        /// Set the value of the `srcset` attribute
+        pub fn set_srcset(
+            &mut self,
+            value: std::option::Option<impl Into<std::borrow::Cow<'static, str>>>,
+        ) {
+            self.sys.srcset = value.map(|v| v.into());
+        }
+        /// Get the value of the `sizes` attribute
+        pub fn sizes(&self) -> std::option::Option<&str> {
+            self.sys.sizes.as_deref()
+        }
+        /// Set the value of the `sizes` attribute
+        pub fn set_sizes(
+            &mut self,
+            value: std::option::Option<impl Into<std::borrow::Cow<'static, str>>>,
+        ) {
+            self.sys.sizes = value.map(|v| v.into());
+        }
+        /// Get the value of the `width` attribute
+        pub fn width(&self) -> std::option::Option<i64> {
+            self.sys.width
+        }
+        /// Set the value of the `width` attribute
+        pub fn set_width(&mut self, value: std::option::Option<i64>) {
+            self.sys.width = value;
+        }
+        /// Get the value of the `height` attribute
+        pub fn height(&self) -> std::option::Option<i64> {
+            self.sys.height
+        }
+        /// Set the value of the `height` attribute
+        pub fn set_height(&mut self, value: std::option::Option<i64>) {
+            self.sys.height = value;
+        }
         /// Get the value of the `accesskey` attribute
         pub fn access_key(&self) -> std::option::Option<&str> {
             self.sys.access_key.as_deref()
@@ -414,6 +463,40 @@ pub mod builder {
             value: impl Into<std::borrow::Cow<'static, str>>,
         ) -> &mut Self {
             self.element.set_media(Some(value.into()));
+            self
+        }
+        /// Set the value of the `src` attribute
+        pub fn src(
+            &mut self,
+            value: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            self.element.set_src(Some(value.into()));
+            self
+        }
+        /// Set the value of the `srcset` attribute
+        pub fn srcset(
+            &mut self,
+            value: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            self.element.set_srcset(Some(value.into()));
+            self
+        }
+        /// Set the value of the `sizes` attribute
+        pub fn sizes(
+            &mut self,
+            value: impl Into<std::borrow::Cow<'static, str>>,
+        ) -> &mut Self {
+            self.element.set_sizes(Some(value.into()));
+            self
+        }
+        /// Set the value of the `width` attribute
+        pub fn width(&mut self, value: i64) -> &mut Self {
+            self.element.set_width(Some(value));
+            self
+        }
+        /// Set the value of the `height` attribute
+        pub fn height(&mut self, value: i64) -> &mut Self {
+            self.element.set_height(Some(value));
             self
         }
         /// Set the value of the `accesskey` attribute

--- a/resources/merged/elements/li.json
+++ b/resources/merged/elements/li.json
@@ -7,6 +7,12 @@
   "has_closing_tag": true,
   "attributes": [
     {
+      "name": "value",
+      "description": "Ordinal value of the list item. Only if the element is not a child of an `ul` or `menu` element.",
+      "field_name": "value",
+      "ty": "String"
+    },
+    {
       "name": "role",
       "description": "Describes the role(s) the current element plays in the context of the document.",
       "field_name": "role",

--- a/resources/merged/elements/source.json
+++ b/resources/merged/elements/source.json
@@ -17,6 +17,36 @@
       "description": "Applicable media",
       "field_name": "media",
       "ty": "String"
+    },
+    {
+      "name": "src",
+      "description": "Address of the resource (in audio or video)",
+      "field_name": "src",
+      "ty": "String"
+    },
+    {
+      "name": "srcset",
+      "description": "Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (in picture)",
+      "field_name": "srcset",
+      "ty": "String"
+    },
+    {
+      "name": "sizes",
+      "description": "Image sizes for different page layouts (in picture)",
+      "field_name": "sizes",
+      "ty": "String"
+    },
+    {
+      "name": "width",
+      "description": "Horizontal dimension (in picture)",
+      "field_name": "width",
+      "ty": "Integer"
+    },
+    {
+      "name": "height",
+      "description": "Vertical dimension (in picture)",
+      "field_name": "height",
+      "ty": "Integer"
     }
   ],
   "dom_interface": "HTMLSourceElement",

--- a/resources/parsed/elements/li.json
+++ b/resources/parsed/elements/li.json
@@ -5,7 +5,14 @@
   "mdn_link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li",
   "has_global_attributes": true,
   "has_closing_tag": true,
-  "attributes": [],
+  "attributes": [
+    {
+      "name": "value",
+      "description": "Ordinal value of the list item. Only if the element is not a child of an `ul` or `menu` element.",
+      "field_name": "value",
+      "ty": "String"
+    }
+  ],
   "dom_interface": "HTMLLIElement",
   "content_categories": [],
   "permitted_content": [

--- a/resources/parsed/elements/source.json
+++ b/resources/parsed/elements/source.json
@@ -17,6 +17,36 @@
       "description": "Applicable media",
       "field_name": "media",
       "ty": "String"
+    },
+    {
+      "name": "src",
+      "description": "Address of the resource (in audio or video)",
+      "field_name": "src",
+      "ty": "String"
+    },
+    {
+      "name": "srcset",
+      "description": "Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (in picture)",
+      "field_name": "srcset",
+      "ty": "String"
+    },
+    {
+      "name": "sizes",
+      "description": "Image sizes for different page layouts (in picture)",
+      "field_name": "sizes",
+      "ty": "String"
+    },
+    {
+      "name": "width",
+      "description": "Horizontal dimension (in picture)",
+      "field_name": "width",
+      "ty": "String"
+    },
+    {
+      "name": "height",
+      "description": "Vertical dimension (in picture)",
+      "field_name": "height",
+      "ty": "String"
     }
   ],
   "dom_interface": "HTMLSourceElement",


### PR DESCRIPTION
Some attributes, notably ones on `<source>`, are conditional. Previously they were skipped. This made using `<source>` impossible in `<picture>` as it was lacking `srcset` attribute.

This PR includes additional attributes in html-sys and html. Their conditions are not checked at type-level; this is left for a future PR. The generated code includes the condition in the docstring.