### PR TITLE
Replace format! with quote!

### DIFF
--- a/crates/html-bindgen/Cargo.toml
+++ b/crates/html-bindgen/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/yoshuawuyts/html"
 [dependencies]
 weedle = "0.12.0"
 convert_case = "0.6.0"
-indoc = "2.0.0"
 serde = { version = "1.0.152", features = ["derive"] }
 html5ever = { version = "0.26.0" }
 scraper = "0.14.0"
@@ -19,3 +18,5 @@ prettyplease = "0.2.4"
 syn = "2"
 regex = "1"
 once_cell = "1"
+quote = "1.0.33"
+proc-macro2 = "1.0.66"

--- a/crates/html-bindgen/src/generate/html/builder.rs
+++ b/crates/html-bindgen/src/generate/html/builder.rs
@@ -1,13 +1,15 @@
 use crate::parse::{Attribute, AttributeType};
 use convert_case::{Case, Casing};
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
 
 pub(crate) fn gen_builder(
-    struct_name: &str,
+    struct_name: &Ident,
     permitted_child_elements: &[String],
     method_attributes: &[Attribute],
-) -> String {
-    let builder_ty = format!("{struct_name}Builder");
-    let struct_ty = format!("super::element::{struct_name}");
+) -> TokenStream {
+    let builder_ty = format_ident!("{struct_name}Builder");
+    let struct_ty = quote! { super::element::#struct_name };
     let method_names = permitted_child_elements
         .iter()
         .map(|element_ty| element_ty.to_case(Case::Snake))
@@ -18,71 +20,69 @@ pub(crate) fn gen_builder(
     let element_methods = gen_element_methods(permitted_child_elements);
     let push_append_methods = gen_push_append_methods(&struct_name, has_children);
     let attr_methods = gen_attr_methods(&method_names, method_attributes);
+    let description = format!(" A builder struct for {struct_name}");
 
-    format!(
-        "
-        /// A builder struct for {struct_name}
-        pub struct {builder_ty} {{
-            element: {struct_ty},
-        }}
-    
-        impl {builder_ty} {{
-            pub(crate) fn new(element: {struct_ty}) -> Self {{
-                Self {{ element }}
-            }}
+    quote! {
+        #[doc = #description]
+        pub struct #builder_ty {
+            element: #struct_ty,
+        }
+
+        impl #builder_ty {
+            pub(crate) fn new(element: #struct_ty) -> Self {
+                Self { element }
+            }
 
             /// Finish building the element
-            pub fn build(&mut self) -> {struct_ty} {{
+            pub fn build(&mut self) -> #struct_ty {
                 self.element.clone()
-            }}
+            }
 
             /// Insert a `data-*` property
-            pub fn data(&mut self, data_key: impl Into<std::borrow::Cow<'static, str>>, value: impl Into<std::borrow::Cow<'static, str>>) -> &mut {builder_ty} {{
+            pub fn data(&mut self, data_key: impl Into<std::borrow::Cow<'static, str>>, value: impl Into<std::borrow::Cow<'static, str>>) -> &mut #builder_ty {
                 self.element.data_map_mut().insert(data_key.into(), value.into());
                 self
-            }}
-    
-            {element_methods}
-            {attr_methods}
-            {push_append_methods}
-        }}
-        "
-    )
+            }
+
+            #element_methods
+            #attr_methods
+            #push_append_methods
+        }
+    }
 }
 
-fn gen_push_append_methods(struct_name: &str, has_children: bool) -> String {
+fn gen_push_append_methods(struct_name: &Ident, has_children: bool) -> TokenStream {
     if !has_children {
-        return String::new();
+        return quote! {};
     }
-    let child_ty = format!("crate::generated::all::children::{struct_name}Child");
-    format!(
-        "
+    let child_name = format_ident!("{struct_name}Child");
+    let child_ty = quote! { crate::generated::all::children::#child_name };
+    quote! {
         /// Push a new child element to the list of children.
         pub fn push<T>(&mut self, child_el: T) -> &mut Self
         where
-            T: Into<{child_ty}>,
-        {{
+            T: Into<#child_ty>,
+        {
             let child_el = child_el.into();
             self.element.children_mut().push(child_el);
             self
-        }}
+        }
 
         /// Extend the list of children with an iterator of child elements.
-        pub fn extend<I, T>(&mut self, iter: I) -> &mut Self 
+        pub fn extend<I, T>(&mut self, iter: I) -> &mut Self
         where
             I: IntoIterator<Item = T>,
-            T: Into<{child_ty}>,
-        {{
+            T: Into<#child_ty>,
+        {
             let iter = iter.into_iter()
                 .map(|child_el| child_el.into());
             self.element.children_mut().extend(iter);
             self
-        }}
-    "
-    )
+        }
+    }
 }
 
-fn gen_element_methods(permitted_child_elements: &[String]) -> String {
+fn gen_element_methods(permitted_child_elements: &[String]) -> TokenStream {
     permitted_child_elements
         .iter()
         .map(|element_ty| {
@@ -90,43 +90,46 @@ fn gen_element_methods(permitted_child_elements: &[String]) -> String {
                 "data" => "data_el".to_owned(),
                 other => other.to_owned(),
             };
+            let method_name = format_ident!("{method_name}");
 
             match element_ty.as_str() {
                 "Text" => {
-                    // String::new()
-                    format!("/// Append a new text element.
-                            pub fn text(&mut self, s: impl Into<std::borrow::Cow<'static, str>>) -> &mut Self {{
-                                let cow = s.into();
-                                self.element.children_mut().push(cow.into());
-                                self
-                            }}"
-                        )
+                    quote! {
+                        /// Append a new text element.
+                        pub fn text(&mut self, s: impl Into<std::borrow::Cow<'static, str>>) -> &mut Self {
+                            let cow = s.into();
+                            self.element.children_mut().push(cow.into());
+                            self
+                        }
+                    }
                 }
                 element_ty => {
-                    let ty = format!("crate::generated::all::{element_ty}");
-                    let ty_builder =
-                        format!("crate::generated::all::builders::{element_ty}Builder");
-                    format!(
-                        "/// Append a new `{element_ty}` element
-                        pub fn {method_name}<F>(&mut self, f: F) -> &mut Self
+                    let element_ty = format_ident!("{element_ty}");
+                    let ty = quote! { crate::generated::all::#element_ty };
+                    let builder_name = format_ident!("{element_ty}Builder");
+                    let ty_builder = quote! { crate::generated::all::builders::#builder_name };
+                    let description = format!(" Append a new `{element_ty}` element");
+                    quote! {
+                        #[doc = #description]
+                        pub fn #method_name<F>(&mut self, f: F) -> &mut Self
                         where F:
-                            for<'a> FnOnce(&'a mut {ty_builder}) -> &'a mut {ty_builder}
-                        {{
-                            let ty: {ty} = Default::default();
-                            let mut ty_builder = {ty_builder}::new(ty);
+                            for<'a> FnOnce(&'a mut #ty_builder) -> &'a mut #ty_builder
+                        {
+                            let ty: #ty = Default::default();
+                            let mut ty_builder = #ty_builder::new(ty);
                             (f)(&mut ty_builder);
                             let ty = ty_builder.build();
                             self.element.children_mut().push(ty.into());
                             self
-                        }}"
-                    )
+                        }
+                    }
                 }
             }
         })
         .collect()
 }
 
-fn gen_attr_methods(permitted_child_elements: &[String], attributes: &[Attribute]) -> String {
+fn gen_attr_methods(permitted_child_elements: &[String], attributes: &[Attribute]) -> TokenStream {
     attributes
         .into_iter()
         .map(|attr| {
@@ -145,26 +148,28 @@ fn gen_attr_methods(permitted_child_elements: &[String], attributes: &[Attribute
                 "data" => "data_attr".to_owned(),
                 other => other.to_owned(),
             };
+            let method_name = format_ident!("{method_name}");
 
             let param_ty = match &attr.ty {
-                AttributeType::Bool => "bool".to_owned(),
-                AttributeType::String => "impl Into<std::borrow::Cow<'static, str>>".to_owned(),
-                ty => format!("{ty}"),
+                AttributeType::Bool => quote! { bool },
+                AttributeType::String => quote! { impl Into<std::borrow::Cow<'static, str>> },
+                ty => quote! { #ty },
             };
 
+            let setter_name = format_ident!("set_{field_name}");
             let field_setter = match &attr.ty {
-                AttributeType::String => format!("Some(value.into())"),
-                AttributeType::Bool => format!("value"),
-                _ => format!("Some(value)"),
+                AttributeType::String => quote! { Some(value.into()) },
+                AttributeType::Bool => quote! { value },
+                _ => quote! { Some(value) },
             };
-            format!(
-                "
-            /// Set the value of the `{name}` attribute
-            pub fn {method_name}(&mut self, value: {param_ty}) -> &mut Self {{
-                self.element.set_{field_name}({field_setter});
-                self
-            }}",
-            )
+            let description = format!(" Set the value of the `{name}` attribute");
+            quote! {
+                #[doc = #description]
+                pub fn #method_name(&mut self, value: #param_ty) -> &mut Self {
+                    self.element.#setter_name(#field_setter);
+                    self
+                }
+            }
         })
         .collect()
 }

--- a/crates/html-bindgen/src/generate/mod.rs
+++ b/crates/html-bindgen/src/generate/mod.rs
@@ -1,6 +1,8 @@
 pub mod html;
 pub mod sys;
 
+use crate::Result;
+use proc_macro2::TokenStream;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -21,5 +23,12 @@ pub struct ModuleMapping {
 pub struct CodeFile {
     pub filename: String,
     pub dir: String,
-    pub code: String,
+    pub code: TokenStream,
+}
+
+impl CodeFile {
+    pub fn code(&self) -> Result<String> {
+        let file = syn::parse_file(&self.code.to_string())?;
+        Ok(prettyplease::unparse(&file))
+    }
 }

--- a/crates/html-bindgen/src/generate/sys/mod.rs
+++ b/crates/html-bindgen/src/generate/sys/mod.rs
@@ -1,51 +1,54 @@
 use super::{CodeFile, Module};
-use std::fmt::Write;
 use std::{collections::HashMap, iter};
 
 use crate::merge::MergedElement;
 use crate::parse::{Attribute, AttributeType};
-use crate::{utils, Result};
-use indoc::{formatdoc, writedoc};
+use crate::Result;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 
-const INCLUDES: &str = r##"
-/// Render an element to a writer.
-pub trait RenderElement {
-    /// Write the opening tag to a writer.
-    fn write_opening_tag<W: std::fmt::Write >(&self, writer: &mut W) -> std::fmt::Result;
+fn includes() -> TokenStream {
+    quote! {
+        /// Render an element to a writer.
+        pub trait RenderElement {
+            /// Write the opening tag to a writer.
+            fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result;
 
-    /// Write the closing tag to a writer, if one is available.
-    fn write_closing_tag<W: std::fmt::Write >(&self, writer: &mut W) -> std::fmt::Result;
-}
-
-/// Container for `data-*` attributes.
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct DataMap {
-    map: std::collections::HashMap<std::borrow::Cow<'static, str>, std::borrow::Cow<'static, str>>,
-}
-
-impl std::ops::Deref for DataMap {
-    type Target = std::collections::HashMap<std::borrow::Cow<'static, str>, std::borrow::Cow<'static, str>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.map
-    }
-}
-
-impl std::ops::DerefMut for DataMap {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.map
-    }
-}
-
-impl std::fmt::Display for DataMap {
-    fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (key, value) in self.map.iter() {
-            write!(writer, r#" data-{key}="{value}""#)?;
+            /// Write the closing tag to a writer, if one is available.
+            fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result;
         }
-        Ok(())
+
+        /// Container for `data-*` attributes.
+        #[derive(Debug, Clone, PartialEq, Default)]
+        pub struct DataMap {
+            map: std::collections::HashMap<std::borrow::Cow<'static, str>, std::borrow::Cow<'static, str>>,
+        }
+
+        impl std::ops::Deref for DataMap {
+            type Target =
+                std::collections::HashMap<std::borrow::Cow<'static, str>, std::borrow::Cow<'static, str>>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.map
+            }
+        }
+
+        impl std::ops::DerefMut for DataMap {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.map
+            }
+        }
+
+        impl std::fmt::Display for DataMap {
+            fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                for (key, value) in self.map.iter() {
+                    write!(writer, r#" data-{key}="{value}""#)?;
+                }
+                Ok(())
+            }
+        }
     }
 }
-"##;
 
 pub fn generate(
     merged: impl Iterator<Item = Result<MergedElement>>,
@@ -69,21 +72,24 @@ pub fn generate(
     for (dir, mut filenames) in generated {
         filenames.sort();
         dirs.push(dir.clone());
-        let code = filenames
-            .into_iter()
-            .map(|name| format!("mod {name};\npub use {name}::*;"))
-            .collect::<String>();
+        let code = filenames.into_iter().map(|name| {
+            let name = format_ident!("{name}");
+            quote! {
+                mod #name;
+                pub use #name::*;
+            }
+        });
 
         let module = modules.iter().find(|el| &el.name == &dir).unwrap();
-        let description = &module.description;
-        let code = format!(
-            "//! {description}
-            {code}"
-        );
+        let description = format!(" {}", module.description);
+        let code = quote! {
+            #![doc = #description]
+            #(#code)*
+        };
 
         output.push(CodeFile {
             filename: "mod.rs".to_owned(),
-            code: utils::fmt(&code).expect("could not parse code"),
+            code,
             dir,
         })
     }
@@ -92,37 +98,32 @@ pub fn generate(
     // generate `lib.rs` file
     let code = dirs
         .into_iter()
-        .map(|d| format!("pub mod {d};\n"))
-        .chain(iter::once(INCLUDES.to_owned()))
+        .map(|dir| format_ident!("{dir}"))
+        .map(|dir| quote! { pub mod #dir; })
+        .chain(iter::once(includes()))
         .chain(iter::once({
             let fields = generate_fields(global_attributes);
+            let display_attrs = global_attributes.iter().map(generate_attribute_display);
 
-            let mut display_attrs = String::new();
-            for attr in global_attributes {
-                display_attrs.push_str(&generate_attribute_display(&attr));
+            quote! {
+                /// The "global attributes" struct
+                #[derive(Debug, Clone, PartialEq, Default)]
+                pub struct GlobalAttributes {
+                    #fields
+                }
+
+                impl std::fmt::Display for GlobalAttributes {
+                    fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        #(#display_attrs)*
+                        Ok(())
+                    }
+                }
             }
-            formatdoc!(
-                r#"
-
-                    /// The "global attributes" struct
-                    #[derive(Debug, Clone, PartialEq, Default)]
-                    pub struct GlobalAttributes {{
-                        {fields}
-                    }}
-
-                    impl std::fmt::Display for GlobalAttributes {{
-                        fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
-                            {display_attrs}
-                            Ok(())
-                        }}
-                    }}
-                    "#
-            )
         }))
-        .collect::<String>();
+        .collect::<TokenStream>();
     output.push(CodeFile {
         filename: "lib.rs".to_owned(),
-        code: utils::fmt(&code)?,
+        code,
         dir: String::new(),
     });
 
@@ -142,161 +143,159 @@ fn generate_element(el: MergedElement) -> Result<CodeFile> {
         ..
     } = el;
 
-    let filename = format!("{}.rs", tag_name);
+    let filename = format!("{tag_name}.rs");
+    let struct_name = format_ident!("{struct_name}");
     let fields = generate_fields(&attributes);
     let opening_tag_content = generate_opening_tag(&attributes, &tag_name, has_global_attributes);
     let closing_tag_content = generate_closing_tag(&tag_name, has_closing_tag);
 
     let global_field = match has_global_attributes {
-        true => format!("global_attrs: crate::GlobalAttributes,"),
-        false => String::new(),
+        true => quote! { global_attrs: crate::GlobalAttributes, },
+        false => quote! {},
     };
 
-    let mut code = formatdoc!(
-        r#"/// The HTML `<{tag_name}>` element
-        ///
-        /// [MDN Documentation]({mdn_link})
-        #[doc(alias = "{tag_name}")]
+    let deref_impls = if has_global_attributes {
+        quote! {
+            impl std::ops::Deref for #struct_name {
+                type Target = crate::GlobalAttributes;
+
+                fn deref(&self) -> &Self::Target {
+                    &self.global_attrs
+                }
+            }
+
+            impl std::ops::DerefMut for #struct_name {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut self.global_attrs
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+    let description =
+        format!(" The HTML `<{tag_name}>` element\n\n [MDN Documentation]({mdn_link})");
+    let code = quote! {
+        #[doc = #description]
+        #[doc(alias = #tag_name)]
         #[non_exhaustive]
         #[derive(Debug, Clone, PartialEq, Default)]
-        pub struct {struct_name} {{
+        pub struct #struct_name {
             pub data_map: crate::DataMap,
-            {global_field}
-            {fields}
-        }}
+            #global_field
+            #fields
+        }
 
-        impl crate::RenderElement for {struct_name} {{
-            fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {{
-                {opening_tag_content}
+        impl crate::RenderElement for #struct_name {
+            fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
+                #opening_tag_content
                 Ok(())
-            }}
+            }
 
             #[allow(unused_variables)]
-            fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {{
-                {closing_tag_content}
+            fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
+                #closing_tag_content
                 Ok(())
-            }}
-        }}
+            }
+        }
 
-        impl std::fmt::Display for {struct_name} {{
-            fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
+        impl std::fmt::Display for #struct_name {
+            fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 use crate::RenderElement;
                 self.write_opening_tag(writer)?;
                 self.write_closing_tag(writer)?;
                 Ok(())
-            }}
-        }}
-    "#
-    );
+            }
+        }
 
-    if has_global_attributes {
-        code.push_str(&formatdoc!(
-            r#"
-            impl std::ops::Deref for {struct_name} {{
-                type Target = crate::GlobalAttributes;
-
-                fn deref(&self) -> &Self::Target {{
-                    &self.global_attrs
-                }}
-            }}
-
-            impl std::ops::DerefMut for {struct_name} {{
-                fn deref_mut(&mut self) -> &mut Self::Target {{
-                    &mut self.global_attrs
-                }}
-            }}"#
-        ));
-    }
+        #deref_impls
+    };
 
     Ok(CodeFile {
         filename,
-        code: utils::fmt(&code)?,
+        code,
         dir,
     })
 }
 
-fn generate_fields(attributes: &[Attribute]) -> String {
-    let mut output = String::new();
-    for attr in attributes {
-        let description = &attr.description;
-        let field_name = &attr.field_name;
+fn generate_fields(attributes: &[Attribute]) -> TokenStream {
+    let attributes = attributes.iter().map(|attr| {
+        let description = format!(" {}", attr.description);
+        let field_name = format_ident!("{}", attr.field_name);
         let ty = &attr.ty;
-        output.push_str(&match ty {
-            AttributeType::Bool => format!(
-                "/// {description}
-                pub {field_name}: bool,
-                "
-            ),
-            AttributeType::String => format!(
-                "/// {description}
-             pub {field_name}: std::option::Option<std::borrow::Cow<'static, str>>,
-            "
-            ),
-            _ => format!(
-                "/// {description}
-             pub {field_name}: std::option::Option<{ty}>,
-            "
-            ),
-        });
-    }
-    output
+
+        match ty {
+            AttributeType::Bool => quote! {
+                #[doc = #description]
+                pub #field_name: bool,
+            },
+            AttributeType::String => quote! {
+                #[doc = #description]
+                pub #field_name: std::option::Option<std::borrow::Cow<'static, str>>,
+            },
+            _ => quote! {
+                #[doc = #description]
+                pub #field_name: std::option::Option<#ty>,
+            },
+        }
+    });
+
+    quote! { #(#attributes)* }
 }
 
 fn generate_opening_tag(
     attributes: &[Attribute],
     tag_name: &str,
     has_global_attrs: bool,
-) -> String {
+) -> TokenStream {
     let preamble = match tag_name {
         "html" => "<!DOCTYPE html>",
         _ => "",
     };
-    let mut output = formatdoc!(
-        r#"
-        write!(writer, "{preamble}<{tag_name}")?;
-    "#
-    );
-    for attr in attributes {
-        output.push_str(&generate_attribute_display(&attr));
-    }
-    if has_global_attrs {
-        output.push_str(&format!(r#"write!(writer, "{{}}", self.global_attrs)?;"#));
-    }
+    let attributes = attributes
+        .iter()
+        .map(|attr| generate_attribute_display(&attr))
+        .chain(if has_global_attrs {
+            Some(quote! { write!(writer, "{}", self.global_attrs)?; })
+        } else {
+            None
+        });
 
-    output.push_str(&format!(r#"write!(writer, "{{}}", self.data_map)?;"#));
-    writedoc!(&mut output, r#"write!(writer, ">")?;"#).unwrap();
-    output
+    quote! {
+        write!(writer, "{}<{}", #preamble, #tag_name)?;
+        #(#attributes)*
+        write!(writer, "{}", self.data_map)?;
+        write!(writer, ">")?;
+    }
 }
 
-fn generate_closing_tag(tag_name: &str, has_closing_tag: bool) -> String {
+fn generate_closing_tag(tag_name: &str, has_closing_tag: bool) -> TokenStream {
     if has_closing_tag {
-        formatdoc!(
-            r#"write!(writer, "</{tag_name}>")?;
-        "#
-        )
+        quote! { write!(writer, "</{}>", #tag_name)?; }
     } else {
-        String::new()
+        quote! {}
     }
 }
 
-fn generate_attribute_display(attr: &Attribute) -> String {
+fn generate_attribute_display(attr: &Attribute) -> TokenStream {
     let Attribute {
         name,
         field_name,
         ty,
         ..
     } = &attr;
+    let field_name = format_ident!("{field_name}");
     match ty {
-        AttributeType::Bool => format!(
-            r##"if self.{field_name} {{
-                    write!(writer, r#" {name}"#)?;
-            }}"##
-        ),
-        AttributeType::String | AttributeType::Integer | AttributeType::Float => format!(
-            r##"if let Some(field) = self.{field_name}.as_ref() {{
-                write!(writer, r#" {name}="{{field}}""#)?;
-            }}"##
-        ),
+        AttributeType::Bool => quote! {
+            if self.#field_name {
+                write!(writer, " {}", #name)?;
+            }
+        },
+        AttributeType::String | AttributeType::Integer | AttributeType::Float => quote! {
+            if let Some(field) = self.#field_name.as_ref() {
+                write!(writer, r#" {}="{field}""#, #name)?;
+            }
+        },
         AttributeType::Identifier(_) => todo!(),
         AttributeType::Enumerable(_) => todo!(),
     }

--- a/crates/html-bindgen/src/parse/mod.rs
+++ b/crates/html-bindgen/src/parse/mod.rs
@@ -8,10 +8,11 @@ pub use aria::{
 };
 use convert_case::{Case, Casing};
 pub use elements::{parse_elements, parse_struct_name, ParsedElement};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
 pub use webidls::{parse_webidls, ParsedInterface};
 
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
 
 /// An attribute
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -32,13 +33,13 @@ pub enum AttributeType {
     Enumerable(Vec<String>),
 }
 
-impl Display for AttributeType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ToTokens for AttributeType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            AttributeType::Bool => write!(f, "bool"),
-            AttributeType::String => write!(f, "String"),
-            AttributeType::Integer => write!(f, "i64"),
-            AttributeType::Float => write!(f, "f64"),
+            AttributeType::Bool => tokens.extend(quote! { bool }),
+            AttributeType::String => tokens.extend(quote! { String }),
+            AttributeType::Integer => tokens.extend(quote! { i64 }),
+            AttributeType::Float => tokens.extend(quote! { f64 }),
             AttributeType::Identifier(_) => todo!("identifier attr not yet implemented"),
             AttributeType::Enumerable(_) => todo!("enum attr not yet implemented"),
         }

--- a/crates/html-bindgen/src/utils.rs
+++ b/crates/html-bindgen/src/utils.rs
@@ -1,11 +1,3 @@
-use crate::Result;
-
-/// Format generated Rust code prior to writing it.
-pub fn fmt(input: &str) -> Result<String> {
-    let syntax_tree = syn::parse_file(&input)?;
-    Ok(prettyplease::unparse(&syntax_tree))
-}
-
 /// Extract the interface name from a webidl definition.
 ///
 /// This tries to find the `interface` types only. It does not

--- a/crates/html-sys/src/edits/del.rs
+++ b/crates/html-sys/src/edits/del.rs
@@ -1,6 +1,6 @@
-/// The HTML `<del>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
+/** The HTML `<del>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)*/
 #[doc(alias = "del")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -120,165 +120,165 @@ pub struct DeletedText {
 }
 impl crate::RenderElement for DeletedText {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<del")?;
+        write!(writer, "{}<{}", "", "del")?;
         if let Some(field) = self.cite.as_ref() {
-            write!(writer, r#" cite="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "cite")?;
         }
         if let Some(field) = self.date_time.as_ref() {
-            write!(writer, r#" datetime="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "datetime")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -287,7 +287,7 @@ impl crate::RenderElement for DeletedText {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</del>")?;
+        write!(writer, "</{}>", "del")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/edits/ins.rs
+++ b/crates/html-sys/src/edits/ins.rs
@@ -1,6 +1,6 @@
-/// The HTML `<ins>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
+/** The HTML `<ins>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)*/
 #[doc(alias = "ins")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -120,165 +120,165 @@ pub struct InsertedText {
 }
 impl crate::RenderElement for InsertedText {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<ins")?;
+        write!(writer, "{}<{}", "", "ins")?;
         if let Some(field) = self.cite.as_ref() {
-            write!(writer, r#" cite="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "cite")?;
         }
         if let Some(field) = self.date_time.as_ref() {
-            write!(writer, r#" datetime="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "datetime")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -287,7 +287,7 @@ impl crate::RenderElement for InsertedText {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</ins>")?;
+        write!(writer, "</{}>", "ins")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/embedded/area.rs
+++ b/crates/html-sys/src/embedded/area.rs
@@ -1,6 +1,6 @@
-/// The HTML `<area>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area)
+/** The HTML `<area>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area)*/
 #[doc(alias = "area")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -84,114 +84,114 @@ pub struct ImageMapArea {
 }
 impl crate::RenderElement for ImageMapArea {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<area")?;
+        write!(writer, "{}<{}", "", "area")?;
         if let Some(field) = self.alt.as_ref() {
-            write!(writer, r#" alt="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "alt")?;
         }
         if let Some(field) = self.coords.as_ref() {
-            write!(writer, r#" coords="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "coords")?;
         }
         if let Some(field) = self.shape.as_ref() {
-            write!(writer, r#" shape="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "shape")?;
         }
         if let Some(field) = self.href.as_ref() {
-            write!(writer, r#" href="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "href")?;
         }
         if let Some(field) = self.target.as_ref() {
-            write!(writer, r#" target="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "target")?;
         }
         if let Some(field) = self.download.as_ref() {
-            write!(writer, r#" download="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "download")?;
         }
         if let Some(field) = self.ping.as_ref() {
-            write!(writer, r#" ping="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "ping")?;
         }
         if let Some(field) = self.rel.as_ref() {
-            write!(writer, r#" rel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "rel")?;
         }
         if let Some(field) = self.referrerpolicy.as_ref() {
-            write!(writer, r#" referrerpolicy="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "referrerpolicy")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/embedded/audio.rs
+++ b/crates/html-sys/src/embedded/audio.rs
@@ -1,6 +1,6 @@
-/// The HTML `<audio>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
+/** The HTML `<audio>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)*/
 #[doc(alias = "audio")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -82,108 +82,108 @@ pub struct Audio {
 }
 impl crate::RenderElement for Audio {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<audio")?;
+        write!(writer, "{}<{}", "", "audio")?;
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.crossorigin.as_ref() {
-            write!(writer, r#" crossorigin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "crossorigin")?;
         }
         if let Some(field) = self.preload.as_ref() {
-            write!(writer, r#" preload="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "preload")?;
         }
         if let Some(field) = self.autoplay.as_ref() {
-            write!(writer, r#" autoplay="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autoplay")?;
         }
         if let Some(field) = self.loop_.as_ref() {
-            write!(writer, r#" loop="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "loop")?;
         }
         if let Some(field) = self.muted.as_ref() {
-            write!(writer, r#" muted="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "muted")?;
         }
         if let Some(field) = self.controls.as_ref() {
-            write!(writer, r#" controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "controls")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -192,7 +192,7 @@ impl crate::RenderElement for Audio {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</audio>")?;
+        write!(writer, "</{}>", "audio")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/embedded/embed.rs
+++ b/crates/html-sys/src/embedded/embed.rs
@@ -1,6 +1,6 @@
-/// The HTML `<embed>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed)
+/** The HTML `<embed>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed)*/
 #[doc(alias = "embed")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -76,99 +76,99 @@ pub struct Embed {
 }
 impl crate::RenderElement for Embed {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<embed")?;
+        write!(writer, "{}<{}", "", "embed")?;
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/embedded/iframe.rs
+++ b/crates/html-sys/src/embedded/iframe.rs
@@ -1,6 +1,6 @@
-/// The HTML `<iframe>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)
+/** The HTML `<iframe>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)*/
 #[doc(alias = "iframe")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -88,117 +88,117 @@ pub struct Iframe {
 }
 impl crate::RenderElement for Iframe {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<iframe")?;
+        write!(writer, "{}<{}", "", "iframe")?;
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.srcdoc.as_ref() {
-            write!(writer, r#" srcdoc="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "srcdoc")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.sandbox.as_ref() {
-            write!(writer, r#" sandbox="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "sandbox")?;
         }
         if let Some(field) = self.allow.as_ref() {
-            write!(writer, r#" allow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "allow")?;
         }
         if let Some(field) = self.allowfullscreen.as_ref() {
-            write!(writer, r#" allowfullscreen="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "allowfullscreen")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.referrerpolicy.as_ref() {
-            write!(writer, r#" referrerpolicy="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "referrerpolicy")?;
         }
         if let Some(field) = self.loading.as_ref() {
-            write!(writer, r#" loading="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "loading")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -207,7 +207,7 @@ impl crate::RenderElement for Iframe {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</iframe>")?;
+        write!(writer, "</{}>", "iframe")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/embedded/img.rs
+++ b/crates/html-sys/src/embedded/img.rs
@@ -1,6 +1,6 @@
-/// The HTML `<img>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
+/** The HTML `<img>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)*/
 #[doc(alias = "img")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,162 +116,162 @@ pub struct Image {
 }
 impl crate::RenderElement for Image {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<img")?;
+        write!(writer, "{}<{}", "", "img")?;
         if let Some(field) = self.alt.as_ref() {
-            write!(writer, r#" alt="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "alt")?;
         }
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.srcset.as_ref() {
-            write!(writer, r#" srcset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "srcset")?;
         }
         if let Some(field) = self.sizes.as_ref() {
-            write!(writer, r#" sizes="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "sizes")?;
         }
         if let Some(field) = self.crossorigin.as_ref() {
-            write!(writer, r#" crossorigin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "crossorigin")?;
         }
         if let Some(field) = self.usemap.as_ref() {
-            write!(writer, r#" usemap="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "usemap")?;
         }
         if let Some(field) = self.ismap.as_ref() {
-            write!(writer, r#" ismap="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "ismap")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.referrerpolicy.as_ref() {
-            write!(writer, r#" referrerpolicy="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "referrerpolicy")?;
         }
         if let Some(field) = self.decoding.as_ref() {
-            write!(writer, r#" decoding="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "decoding")?;
         }
         if let Some(field) = self.loading.as_ref() {
-            write!(writer, r#" loading="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "loading")?;
         }
         if let Some(field) = self.fetchpriority.as_ref() {
-            write!(writer, r#" fetchpriority="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "fetchpriority")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/embedded/map.rs
+++ b/crates/html-sys/src/embedded/map.rs
@@ -1,6 +1,6 @@
-/// The HTML `<map>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map)
+/** The HTML `<map>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map)*/
 #[doc(alias = "map")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct ImageMap {
 }
 impl crate::RenderElement for ImageMap {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<map")?;
+        write!(writer, "{}<{}", "", "map")?;
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -23,7 +23,7 @@ impl crate::RenderElement for ImageMap {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</map>")?;
+        write!(writer, "</{}>", "map")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/embedded/object.rs
+++ b/crates/html-sys/src/embedded/object.rs
@@ -1,6 +1,6 @@
-/// The HTML `<object>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object)
+/** The HTML `<object>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object)*/
 #[doc(alias = "object")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -80,105 +80,105 @@ pub struct Object {
 }
 impl crate::RenderElement for Object {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<object")?;
+        write!(writer, "{}<{}", "", "object")?;
         if let Some(field) = self.data.as_ref() {
-            write!(writer, r#" data="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "data")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -187,7 +187,7 @@ impl crate::RenderElement for Object {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</object>")?;
+        write!(writer, "</{}>", "object")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/embedded/picture.rs
+++ b/crates/html-sys/src/embedded/picture.rs
@@ -1,6 +1,6 @@
-/// The HTML `<picture>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
+/** The HTML `<picture>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)*/
 #[doc(alias = "picture")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct Picture {
 }
 impl crate::RenderElement for Picture {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<picture")?;
+        write!(writer, "{}<{}", "", "picture")?;
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -23,7 +23,7 @@ impl crate::RenderElement for Picture {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</picture>")?;
+        write!(writer, "</{}>", "picture")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/embedded/source.rs
+++ b/crates/html-sys/src/embedded/source.rs
@@ -1,6 +1,6 @@
-/// The HTML `<source>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
+/** The HTML `<source>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)*/
 #[doc(alias = "source")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -24,27 +24,27 @@ pub struct MediaSource {
 }
 impl crate::RenderElement for MediaSource {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<source")?;
+        write!(writer, "{}<{}", "", "source")?;
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.media.as_ref() {
-            write!(writer, r#" media="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "media")?;
         }
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.srcset.as_ref() {
-            write!(writer, r#" srcset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "srcset")?;
         }
         if let Some(field) = self.sizes.as_ref() {
-            write!(writer, r#" sizes="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "sizes")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/embedded/track.rs
+++ b/crates/html-sys/src/embedded/track.rs
@@ -1,6 +1,6 @@
-/// The HTML `<track>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track)
+/** The HTML `<track>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track)*/
 #[doc(alias = "track")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -20,21 +20,21 @@ pub struct TextTrack {
 }
 impl crate::RenderElement for TextTrack {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<track")?;
+        write!(writer, "{}<{}", "", "track")?;
         if let Some(field) = self.kind.as_ref() {
-            write!(writer, r#" kind="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "kind")?;
         }
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.srclang.as_ref() {
-            write!(writer, r#" srclang="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "srclang")?;
         }
         if let Some(field) = self.label.as_ref() {
-            write!(writer, r#" label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "label")?;
         }
         if self.default {
-            write!(writer, r#" default"#)?;
+            write!(writer, " {}", "default")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/embedded/video.rs
+++ b/crates/html-sys/src/embedded/video.rs
@@ -1,6 +1,6 @@
-/// The HTML `<video>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)
+/** The HTML `<video>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)*/
 #[doc(alias = "video")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -90,120 +90,120 @@ pub struct Video {
 }
 impl crate::RenderElement for Video {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<video")?;
+        write!(writer, "{}<{}", "", "video")?;
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.crossorigin.as_ref() {
-            write!(writer, r#" crossorigin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "crossorigin")?;
         }
         if let Some(field) = self.poster.as_ref() {
-            write!(writer, r#" poster="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "poster")?;
         }
         if let Some(field) = self.preload.as_ref() {
-            write!(writer, r#" preload="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "preload")?;
         }
         if let Some(field) = self.autoplay.as_ref() {
-            write!(writer, r#" autoplay="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autoplay")?;
         }
         if self.plays_inline {
-            write!(writer, r#" playsinline"#)?;
+            write!(writer, " {}", "playsinline")?;
         }
         if let Some(field) = self.loop_.as_ref() {
-            write!(writer, r#" loop="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "loop")?;
         }
         if let Some(field) = self.muted.as_ref() {
-            write!(writer, r#" muted="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "muted")?;
         }
         if let Some(field) = self.controls.as_ref() {
-            write!(writer, r#" controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "controls")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -212,7 +212,7 @@ impl crate::RenderElement for Video {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</video>")?;
+        write!(writer, "</{}>", "video")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/button.rs
+++ b/crates/html-sys/src/forms/button.rs
@@ -1,6 +1,6 @@
-/// The HTML `<button>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)
+/** The HTML `<button>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)*/
 #[doc(alias = "button")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -130,180 +130,180 @@ pub struct Button {
 }
 impl crate::RenderElement for Button {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<button")?;
+        write!(writer, "{}<{}", "", "button")?;
         if self.disabled {
-            write!(writer, r#" disabled"#)?;
+            write!(writer, " {}", "disabled")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if let Some(field) = self.form_action.as_ref() {
-            write!(writer, r#" formaction="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formaction")?;
         }
         if let Some(field) = self.form_enctype.as_ref() {
-            write!(writer, r#" formenctype="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formenctype")?;
         }
         if let Some(field) = self.form_method.as_ref() {
-            write!(writer, r#" formmethod="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formmethod")?;
         }
         if self.form_no_validate {
-            write!(writer, r#" formnovalidate"#)?;
+            write!(writer, " {}", "formnovalidate")?;
         }
         if let Some(field) = self.form_target.as_ref() {
-            write!(writer, r#" formtarget="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formtarget")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.popovertarget.as_ref() {
-            write!(writer, r#" popovertarget="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "popovertarget")?;
         }
         if let Some(field) = self.popovertargetaction.as_ref() {
-            write!(writer, r#" popovertargetaction="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "popovertargetaction")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -312,7 +312,7 @@ impl crate::RenderElement for Button {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</button>")?;
+        write!(writer, "</{}>", "button")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/datalist.rs
+++ b/crates/html-sys/src/forms/datalist.rs
@@ -1,6 +1,6 @@
-/// The HTML `<datalist>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)
+/** The HTML `<datalist>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)*/
 #[doc(alias = "datalist")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct DataList {
 }
 impl crate::RenderElement for DataList {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<datalist")?;
+        write!(writer, "{}<{}", "", "datalist")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -23,7 +23,7 @@ impl crate::RenderElement for DataList {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</datalist>")?;
+        write!(writer, "</{}>", "datalist")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/fieldset.rs
+++ b/crates/html-sys/src/forms/fieldset.rs
@@ -1,6 +1,6 @@
-/// The HTML `<fieldset>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset)
+/** The HTML `<fieldset>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset)*/
 #[doc(alias = "fieldset")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -78,102 +78,102 @@ pub struct Fieldset {
 }
 impl crate::RenderElement for Fieldset {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<fieldset")?;
+        write!(writer, "{}<{}", "", "fieldset")?;
         if self.disabled {
-            write!(writer, r#" disabled"#)?;
+            write!(writer, " {}", "disabled")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -182,7 +182,7 @@ impl crate::RenderElement for Fieldset {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</fieldset>")?;
+        write!(writer, "</{}>", "fieldset")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/form.rs
+++ b/crates/html-sys/src/forms/form.rs
@@ -1,6 +1,6 @@
-/// The HTML `<form>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
+/** The HTML `<form>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)*/
 #[doc(alias = "form")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -78,105 +78,105 @@ pub struct Form {
 }
 impl crate::RenderElement for Form {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<form")?;
+        write!(writer, "{}<{}", "", "form")?;
         if let Some(field) = self.accept_charset.as_ref() {
-            write!(writer, r#" accept-charset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "accept-charset")?;
         }
         if let Some(field) = self.action.as_ref() {
-            write!(writer, r#" action="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "action")?;
         }
         if let Some(field) = self.autocomplete.as_ref() {
-            write!(writer, r#" autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autocomplete")?;
         }
         if let Some(field) = self.enctype.as_ref() {
-            write!(writer, r#" enctype="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "enctype")?;
         }
         if let Some(field) = self.method.as_ref() {
-            write!(writer, r#" method="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "method")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if self.no_validate {
-            write!(writer, r#" novalidate"#)?;
+            write!(writer, " {}", "novalidate")?;
         }
         if let Some(field) = self.target.as_ref() {
-            write!(writer, r#" target="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "target")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -185,7 +185,7 @@ impl crate::RenderElement for Form {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</form>")?;
+        write!(writer, "</{}>", "form")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/input.rs
+++ b/crates/html-sys/src/forms/input.rs
@@ -1,6 +1,6 @@
-/// The HTML `<input>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
+/** The HTML `<input>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)*/
 #[doc(alias = "input")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -176,249 +176,249 @@ pub struct Input {
 }
 impl crate::RenderElement for Input {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<input")?;
+        write!(writer, "{}<{}", "", "input")?;
         if let Some(field) = self.accept.as_ref() {
-            write!(writer, r#" accept="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "accept")?;
         }
         if let Some(field) = self.alt.as_ref() {
-            write!(writer, r#" alt="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "alt")?;
         }
         if let Some(field) = self.autocomplete.as_ref() {
-            write!(writer, r#" autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autocomplete")?;
         }
         if let Some(field) = self.checked.as_ref() {
-            write!(writer, r#" checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "checked")?;
         }
         if let Some(field) = self.dirname.as_ref() {
-            write!(writer, r#" dirname="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "dirname")?;
         }
         if let Some(field) = self.disabled.as_ref() {
-            write!(writer, r#" disabled="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "disabled")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if let Some(field) = self.formaction.as_ref() {
-            write!(writer, r#" formaction="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formaction")?;
         }
         if let Some(field) = self.formenctype.as_ref() {
-            write!(writer, r#" formenctype="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formenctype")?;
         }
         if let Some(field) = self.formmethod.as_ref() {
-            write!(writer, r#" formmethod="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formmethod")?;
         }
         if let Some(field) = self.formnovalidate.as_ref() {
-            write!(writer, r#" formnovalidate="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formnovalidate")?;
         }
         if let Some(field) = self.formtarget.as_ref() {
-            write!(writer, r#" formtarget="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "formtarget")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.list.as_ref() {
-            write!(writer, r#" list="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "list")?;
         }
         if let Some(field) = self.max.as_ref() {
-            write!(writer, r#" max="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "max")?;
         }
         if let Some(field) = self.maxlength.as_ref() {
-            write!(writer, r#" maxlength="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "maxlength")?;
         }
         if let Some(field) = self.min.as_ref() {
-            write!(writer, r#" min="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "min")?;
         }
         if let Some(field) = self.minlength.as_ref() {
-            write!(writer, r#" minlength="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "minlength")?;
         }
         if let Some(field) = self.multiple.as_ref() {
-            write!(writer, r#" multiple="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "multiple")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.pattern.as_ref() {
-            write!(writer, r#" pattern="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "pattern")?;
         }
         if let Some(field) = self.placeholder.as_ref() {
-            write!(writer, r#" placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "placeholder")?;
         }
         if let Some(field) = self.popovertarget.as_ref() {
-            write!(writer, r#" popovertarget="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "popovertarget")?;
         }
         if let Some(field) = self.popovertargetaction.as_ref() {
-            write!(writer, r#" popovertargetaction="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "popovertargetaction")?;
         }
         if let Some(field) = self.readonly.as_ref() {
-            write!(writer, r#" readonly="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "readonly")?;
         }
         if let Some(field) = self.required.as_ref() {
-            write!(writer, r#" required="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "required")?;
         }
         if let Some(field) = self.size.as_ref() {
-            write!(writer, r#" size="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "size")?;
         }
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.step.as_ref() {
-            write!(writer, r#" step="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "step")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/forms/label.rs
+++ b/crates/html-sys/src/forms/label.rs
@@ -1,6 +1,6 @@
-/// The HTML `<label>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)
+/** The HTML `<label>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)*/
 #[doc(alias = "label")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -56,72 +56,72 @@ pub struct Label {
 }
 impl crate::RenderElement for Label {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<label")?;
+        write!(writer, "{}<{}", "", "label")?;
         if let Some(field) = self.for_.as_ref() {
-            write!(writer, r#" for="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "for")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -130,7 +130,7 @@ impl crate::RenderElement for Label {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</label>")?;
+        write!(writer, "</{}>", "label")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/legend.rs
+++ b/crates/html-sys/src/forms/legend.rs
@@ -1,6 +1,6 @@
-/// The HTML `<legend>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend)
+/** The HTML `<legend>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend)*/
 #[doc(alias = "legend")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -54,69 +54,69 @@ pub struct Legend {
 }
 impl crate::RenderElement for Legend {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<legend")?;
+        write!(writer, "{}<{}", "", "legend")?;
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -125,7 +125,7 @@ impl crate::RenderElement for Legend {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</legend>")?;
+        write!(writer, "</{}>", "legend")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/meter.rs
+++ b/crates/html-sys/src/forms/meter.rs
@@ -1,6 +1,6 @@
-/// The HTML `<meter>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter)
+/** The HTML `<meter>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter)*/
 #[doc(alias = "meter")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -80,108 +80,108 @@ pub struct Meter {
 }
 impl crate::RenderElement for Meter {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<meter")?;
+        write!(writer, "{}<{}", "", "meter")?;
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.min.as_ref() {
-            write!(writer, r#" min="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "min")?;
         }
         if let Some(field) = self.max.as_ref() {
-            write!(writer, r#" max="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "max")?;
         }
         if let Some(field) = self.low.as_ref() {
-            write!(writer, r#" low="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "low")?;
         }
         if let Some(field) = self.high.as_ref() {
-            write!(writer, r#" high="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "high")?;
         }
         if let Some(field) = self.optimum.as_ref() {
-            write!(writer, r#" optimum="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "optimum")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -190,7 +190,7 @@ impl crate::RenderElement for Meter {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</meter>")?;
+        write!(writer, "</{}>", "meter")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/optgroup.rs
+++ b/crates/html-sys/src/forms/optgroup.rs
@@ -1,6 +1,6 @@
-/// The HTML `<optgroup>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup)
+/** The HTML `<optgroup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup)*/
 #[doc(alias = "optgroup")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,90 +70,90 @@ pub struct OptionGroup {
 }
 impl crate::RenderElement for OptionGroup {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<optgroup")?;
+        write!(writer, "{}<{}", "", "optgroup")?;
         if self.disabled {
-            write!(writer, r#" disabled"#)?;
+            write!(writer, " {}", "disabled")?;
         }
         if let Some(field) = self.label.as_ref() {
-            write!(writer, r#" label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "label")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -162,7 +162,7 @@ impl crate::RenderElement for OptionGroup {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</optgroup>")?;
+        write!(writer, "</{}>", "optgroup")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/option.rs
+++ b/crates/html-sys/src/forms/option.rs
@@ -1,6 +1,6 @@
-/// The HTML `<option>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option)
+/** The HTML `<option>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option)*/
 #[doc(alias = "option")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -78,105 +78,105 @@ pub struct Option {
 }
 impl crate::RenderElement for Option {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<option")?;
+        write!(writer, "{}<{}", "", "option")?;
         if self.disabled {
-            write!(writer, r#" disabled"#)?;
+            write!(writer, " {}", "disabled")?;
         }
         if let Some(field) = self.label.as_ref() {
-            write!(writer, r#" label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "label")?;
         }
         if self.selected {
-            write!(writer, r#" selected"#)?;
+            write!(writer, " {}", "selected")?;
         }
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -185,7 +185,7 @@ impl crate::RenderElement for Option {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</option>")?;
+        write!(writer, "</{}>", "option")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/output.rs
+++ b/crates/html-sys/src/forms/output.rs
@@ -1,6 +1,6 @@
-/// The HTML `<output>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output)
+/** The HTML `<output>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output)*/
 #[doc(alias = "output")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -128,177 +128,177 @@ pub struct Output {
 }
 impl crate::RenderElement for Output {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<output")?;
+        write!(writer, "{}<{}", "", "output")?;
         if let Some(field) = self.for_.as_ref() {
-            write!(writer, r#" for="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "for")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -307,7 +307,7 @@ impl crate::RenderElement for Output {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</output>")?;
+        write!(writer, "</{}>", "output")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/progress.rs
+++ b/crates/html-sys/src/forms/progress.rs
@@ -1,6 +1,6 @@
-/// The HTML `<progress>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress)
+/** The HTML `<progress>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress)*/
 #[doc(alias = "progress")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -74,99 +74,99 @@ pub struct Progress {
 }
 impl crate::RenderElement for Progress {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<progress")?;
+        write!(writer, "{}<{}", "", "progress")?;
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.max.as_ref() {
-            write!(writer, r#" max="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "max")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -175,7 +175,7 @@ impl crate::RenderElement for Progress {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</progress>")?;
+        write!(writer, "</{}>", "progress")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/select.rs
+++ b/crates/html-sys/src/forms/select.rs
@@ -1,6 +1,6 @@
-/// The HTML `<select>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
+/** The HTML `<select>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)*/
 #[doc(alias = "select")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -92,123 +92,123 @@ pub struct Select {
 }
 impl crate::RenderElement for Select {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<select")?;
+        write!(writer, "{}<{}", "", "select")?;
         if let Some(field) = self.autocomplete.as_ref() {
-            write!(writer, r#" autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autocomplete")?;
         }
         if self.disabled {
-            write!(writer, r#" disabled"#)?;
+            write!(writer, " {}", "disabled")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if self.multiple {
-            write!(writer, r#" multiple"#)?;
+            write!(writer, " {}", "multiple")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if self.required {
-            write!(writer, r#" required"#)?;
+            write!(writer, " {}", "required")?;
         }
         if let Some(field) = self.size.as_ref() {
-            write!(writer, r#" size="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "size")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -217,7 +217,7 @@ impl crate::RenderElement for Select {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</select>")?;
+        write!(writer, "</{}>", "select")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/forms/textarea.rs
+++ b/crates/html-sys/src/forms/textarea.rs
@@ -1,6 +1,6 @@
-/// The HTML `<textarea>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
+/** The HTML `<textarea>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)*/
 #[doc(alias = "textarea")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -102,138 +102,138 @@ pub struct TextArea {
 }
 impl crate::RenderElement for TextArea {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<textarea")?;
+        write!(writer, "{}<{}", "", "textarea")?;
         if let Some(field) = self.autocomplete.as_ref() {
-            write!(writer, r#" autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autocomplete")?;
         }
         if let Some(field) = self.cols.as_ref() {
-            write!(writer, r#" cols="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "cols")?;
         }
         if let Some(field) = self.dir_name.as_ref() {
-            write!(writer, r#" dirname="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "dirname")?;
         }
         if self.disabled {
-            write!(writer, r#" disabled"#)?;
+            write!(writer, " {}", "disabled")?;
         }
         if let Some(field) = self.form.as_ref() {
-            write!(writer, r#" form="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "form")?;
         }
         if let Some(field) = self.max_length.as_ref() {
-            write!(writer, r#" maxlength="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "maxlength")?;
         }
         if let Some(field) = self.min_length.as_ref() {
-            write!(writer, r#" minlength="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "minlength")?;
         }
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.placeholder.as_ref() {
-            write!(writer, r#" placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "placeholder")?;
         }
         if self.read_only {
-            write!(writer, r#" readonly"#)?;
+            write!(writer, " {}", "readonly")?;
         }
         if self.required {
-            write!(writer, r#" required"#)?;
+            write!(writer, " {}", "required")?;
         }
         if let Some(field) = self.rows.as_ref() {
-            write!(writer, r#" rows="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "rows")?;
         }
         if let Some(field) = self.wrap.as_ref() {
-            write!(writer, r#" wrap="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "wrap")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -242,7 +242,7 @@ impl crate::RenderElement for TextArea {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</textarea>")?;
+        write!(writer, "</{}>", "textarea")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/interactive/details.rs
+++ b/crates/html-sys/src/interactive/details.rs
@@ -1,6 +1,6 @@
-/// The HTML `<details>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)
+/** The HTML `<details>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)*/
 #[doc(alias = "details")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,90 +70,90 @@ pub struct Details {
 }
 impl crate::RenderElement for Details {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<details")?;
+        write!(writer, "{}<{}", "", "details")?;
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if self.open {
-            write!(writer, r#" open"#)?;
+            write!(writer, " {}", "open")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -162,7 +162,7 @@ impl crate::RenderElement for Details {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</details>")?;
+        write!(writer, "</{}>", "details")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/interactive/dialog.rs
+++ b/crates/html-sys/src/interactive/dialog.rs
@@ -1,6 +1,6 @@
-/// The HTML `<dialog>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+/** The HTML `<dialog>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)*/
 #[doc(alias = "dialog")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -66,87 +66,87 @@ pub struct Dialog {
 }
 impl crate::RenderElement for Dialog {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<dialog")?;
+        write!(writer, "{}<{}", "", "dialog")?;
         if self.open {
-            write!(writer, r#" open"#)?;
+            write!(writer, " {}", "open")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -155,7 +155,7 @@ impl crate::RenderElement for Dialog {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</dialog>")?;
+        write!(writer, "</{}>", "dialog")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/interactive/summary.rs
+++ b/crates/html-sys/src/interactive/summary.rs
@@ -1,6 +1,6 @@
-/// The HTML `<summary>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary)
+/** The HTML `<summary>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary)*/
 #[doc(alias = "summary")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct Summary {
 }
 impl crate::RenderElement for Summary {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<summary")?;
+        write!(writer, "{}<{}", "", "summary")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for Summary {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</summary>")?;
+        write!(writer, "</{}>", "summary")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/lib.rs
+++ b/crates/html-sys/src/lib.rs
@@ -108,88 +108,88 @@ pub struct GlobalAttributes {
 impl std::fmt::Display for GlobalAttributes {
     fn fmt(&self, writer: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(field) = self.access_key.as_ref() {
-            write!(writer, r#" accesskey="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "accesskey")?;
         }
         if let Some(field) = self.auto_capitalize.as_ref() {
-            write!(writer, r#" autocapitalize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "autocapitalize")?;
         }
         if self.autofocus {
-            write!(writer, r#" autofocus"#)?;
+            write!(writer, " {}", "autofocus")?;
         }
         if let Some(field) = self.class.as_ref() {
-            write!(writer, r#" class="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "class")?;
         }
         if let Some(field) = self.content_editable.as_ref() {
-            write!(writer, r#" contenteditable="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "contenteditable")?;
         }
         if let Some(field) = self.direction.as_ref() {
-            write!(writer, r#" dir="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "dir")?;
         }
         if self.draggable {
-            write!(writer, r#" draggable"#)?;
+            write!(writer, " {}", "draggable")?;
         }
         if let Some(field) = self.enter_key_hint.as_ref() {
-            write!(writer, r#" enterkeyhint="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "enterkeyhint")?;
         }
         if let Some(field) = self.export_parts.as_ref() {
-            write!(writer, r#" exportparts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "exportparts")?;
         }
         if let Some(field) = self.hidden.as_ref() {
-            write!(writer, r#" hidden="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "hidden")?;
         }
         if let Some(field) = self.id.as_ref() {
-            write!(writer, r#" id="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "id")?;
         }
         if self.inert {
-            write!(writer, r#" inert"#)?;
+            write!(writer, " {}", "inert")?;
         }
         if let Some(field) = self.input_mode.as_ref() {
-            write!(writer, r#" inputmode="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "inputmode")?;
         }
         if let Some(field) = self.is_.as_ref() {
-            write!(writer, r#" is="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "is")?;
         }
         if let Some(field) = self.item_id.as_ref() {
-            write!(writer, r#" itemid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "itemid")?;
         }
         if let Some(field) = self.item_prop.as_ref() {
-            write!(writer, r#" itemprop="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "itemprop")?;
         }
         if let Some(field) = self.item_ref.as_ref() {
-            write!(writer, r#" itemref="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "itemref")?;
         }
         if let Some(field) = self.item_scope.as_ref() {
-            write!(writer, r#" itemscope="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "itemscope")?;
         }
         if let Some(field) = self.item_type.as_ref() {
-            write!(writer, r#" itemtype="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "itemtype")?;
         }
         if let Some(field) = self.lang.as_ref() {
-            write!(writer, r#" lang="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "lang")?;
         }
         if let Some(field) = self.nonce.as_ref() {
-            write!(writer, r#" nonce="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "nonce")?;
         }
         if let Some(field) = self.part.as_ref() {
-            write!(writer, r#" part="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "part")?;
         }
         if let Some(field) = self.slot.as_ref() {
-            write!(writer, r#" slot="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "slot")?;
         }
         if let Some(field) = self.spellcheck.as_ref() {
-            write!(writer, r#" spellcheck="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "spellcheck")?;
         }
         if let Some(field) = self.style.as_ref() {
-            write!(writer, r#" style="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "style")?;
         }
         if let Some(field) = self.tab_index.as_ref() {
-            write!(writer, r#" tabindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "tabindex")?;
         }
         if let Some(field) = self.title.as_ref() {
-            write!(writer, r#" title="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "title")?;
         }
         if self.translate {
-            write!(writer, r#" translate"#)?;
+            write!(writer, " {}", "translate")?;
         }
         Ok(())
     }

--- a/crates/html-sys/src/metadata/base.rs
+++ b/crates/html-sys/src/metadata/base.rs
@@ -1,6 +1,6 @@
-/// The HTML `<base>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)
+/** The HTML `<base>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)*/
 #[doc(alias = "base")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -14,12 +14,12 @@ pub struct Base {
 }
 impl crate::RenderElement for Base {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<base")?;
+        write!(writer, "{}<{}", "", "base")?;
         if let Some(field) = self.href.as_ref() {
-            write!(writer, r#" href="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "href")?;
         }
         if let Some(field) = self.target.as_ref() {
-            write!(writer, r#" target="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "target")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/metadata/head.rs
+++ b/crates/html-sys/src/metadata/head.rs
@@ -1,6 +1,6 @@
-/// The HTML `<head>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)
+/** The HTML `<head>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)*/
 #[doc(alias = "head")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -10,7 +10,7 @@ pub struct Head {
 }
 impl crate::RenderElement for Head {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<head")?;
+        write!(writer, "{}<{}", "", "head")?;
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
         write!(writer, ">")?;
@@ -18,7 +18,7 @@ impl crate::RenderElement for Head {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</head>")?;
+        write!(writer, "</{}>", "head")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/metadata/link.rs
+++ b/crates/html-sys/src/metadata/link.rs
@@ -1,6 +1,6 @@
-/// The HTML `<link>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)
+/** The HTML `<link>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)*/
 #[doc(alias = "link")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -42,54 +42,54 @@ pub struct Link {
 }
 impl crate::RenderElement for Link {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<link")?;
+        write!(writer, "{}<{}", "", "link")?;
         if let Some(field) = self.href.as_ref() {
-            write!(writer, r#" href="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "href")?;
         }
         if let Some(field) = self.crossorigin.as_ref() {
-            write!(writer, r#" crossorigin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "crossorigin")?;
         }
         if let Some(field) = self.rel.as_ref() {
-            write!(writer, r#" rel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "rel")?;
         }
         if let Some(field) = self.media.as_ref() {
-            write!(writer, r#" media="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "media")?;
         }
         if let Some(field) = self.integrity.as_ref() {
-            write!(writer, r#" integrity="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "integrity")?;
         }
         if let Some(field) = self.hreflang.as_ref() {
-            write!(writer, r#" hreflang="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "hreflang")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.referrerpolicy.as_ref() {
-            write!(writer, r#" referrerpolicy="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "referrerpolicy")?;
         }
         if let Some(field) = self.sizes.as_ref() {
-            write!(writer, r#" sizes="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "sizes")?;
         }
         if let Some(field) = self.imagesrcset.as_ref() {
-            write!(writer, r#" imagesrcset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "imagesrcset")?;
         }
         if let Some(field) = self.imagesizes.as_ref() {
-            write!(writer, r#" imagesizes="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "imagesizes")?;
         }
         if let Some(field) = self.as_.as_ref() {
-            write!(writer, r#" as="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "as")?;
         }
         if let Some(field) = self.blocking.as_ref() {
-            write!(writer, r#" blocking="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "blocking")?;
         }
         if let Some(field) = self.color.as_ref() {
-            write!(writer, r#" color="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "color")?;
         }
         if let Some(field) = self.disabled.as_ref() {
-            write!(writer, r#" disabled="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "disabled")?;
         }
         if let Some(field) = self.fetchpriority.as_ref() {
-            write!(writer, r#" fetchpriority="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "fetchpriority")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/metadata/meta.rs
+++ b/crates/html-sys/src/metadata/meta.rs
@@ -1,6 +1,6 @@
-/// The HTML `<meta>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)
+/** The HTML `<meta>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)*/
 #[doc(alias = "meta")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -20,21 +20,21 @@ pub struct Meta {
 }
 impl crate::RenderElement for Meta {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<meta")?;
+        write!(writer, "{}<{}", "", "meta")?;
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         if let Some(field) = self.http_equiv.as_ref() {
-            write!(writer, r#" http-equiv="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "http-equiv")?;
         }
         if let Some(field) = self.content.as_ref() {
-            write!(writer, r#" content="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "content")?;
         }
         if let Some(field) = self.charset.as_ref() {
-            write!(writer, r#" charset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "charset")?;
         }
         if let Some(field) = self.media.as_ref() {
-            write!(writer, r#" media="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "media")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/metadata/style.rs
+++ b/crates/html-sys/src/metadata/style.rs
@@ -1,6 +1,6 @@
-/// The HTML `<style>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)
+/** The HTML `<style>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)*/
 #[doc(alias = "style")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -14,12 +14,12 @@ pub struct Style {
 }
 impl crate::RenderElement for Style {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<style")?;
+        write!(writer, "{}<{}", "", "style")?;
         if let Some(field) = self.media.as_ref() {
-            write!(writer, r#" media="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "media")?;
         }
         if let Some(field) = self.blocking.as_ref() {
-            write!(writer, r#" blocking="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "blocking")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -28,7 +28,7 @@ impl crate::RenderElement for Style {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</style>")?;
+        write!(writer, "</{}>", "style")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/metadata/title.rs
+++ b/crates/html-sys/src/metadata/title.rs
@@ -1,6 +1,6 @@
-/// The HTML `<title>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
+/** The HTML `<title>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)*/
 #[doc(alias = "title")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -10,7 +10,7 @@ pub struct Title {
 }
 impl crate::RenderElement for Title {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<title")?;
+        write!(writer, "{}<{}", "", "title")?;
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
         write!(writer, ">")?;
@@ -18,7 +18,7 @@ impl crate::RenderElement for Title {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</title>")?;
+        write!(writer, "</{}>", "title")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/root/html.rs
+++ b/crates/html-sys/src/root/html.rs
@@ -1,6 +1,6 @@
-/// The HTML `<html>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)
+/** The HTML `<html>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)*/
 #[doc(alias = "html")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct Html {
 }
 impl crate::RenderElement for Html {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<!DOCTYPE html><html")?;
+        write!(writer, "{}<{}", "<!DOCTYPE html>", "html")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -23,7 +23,7 @@ impl crate::RenderElement for Html {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</html>")?;
+        write!(writer, "</{}>", "html")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/scripting/canvas.rs
+++ b/crates/html-sys/src/scripting/canvas.rs
@@ -1,6 +1,6 @@
-/// The HTML `<canvas>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas)
+/** The HTML `<canvas>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas)*/
 #[doc(alias = "canvas")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -126,174 +126,174 @@ pub struct Canvas {
 }
 impl crate::RenderElement for Canvas {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<canvas")?;
+        write!(writer, "{}<{}", "", "canvas")?;
         if let Some(field) = self.width.as_ref() {
-            write!(writer, r#" width="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "width")?;
         }
         if let Some(field) = self.height.as_ref() {
-            write!(writer, r#" height="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "height")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -302,7 +302,7 @@ impl crate::RenderElement for Canvas {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</canvas>")?;
+        write!(writer, "</{}>", "canvas")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/scripting/noscript.rs
+++ b/crates/html-sys/src/scripting/noscript.rs
@@ -1,6 +1,6 @@
-/// The HTML `<noscript>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)
+/** The HTML `<noscript>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)*/
 #[doc(alias = "noscript")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -10,7 +10,7 @@ pub struct NoScript {
 }
 impl crate::RenderElement for NoScript {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<noscript")?;
+        write!(writer, "{}<{}", "", "noscript")?;
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
         write!(writer, ">")?;
@@ -18,7 +18,7 @@ impl crate::RenderElement for NoScript {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</noscript>")?;
+        write!(writer, "</{}>", "noscript")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/scripting/script.rs
+++ b/crates/html-sys/src/scripting/script.rs
@@ -1,6 +1,6 @@
-/// The HTML `<script>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)
+/** The HTML `<script>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)*/
 #[doc(alias = "script")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -30,36 +30,36 @@ pub struct Script {
 }
 impl crate::RenderElement for Script {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<script")?;
+        write!(writer, "{}<{}", "", "script")?;
         if let Some(field) = self.src.as_ref() {
-            write!(writer, r#" src="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "src")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.nomodule.as_ref() {
-            write!(writer, r#" nomodule="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "nomodule")?;
         }
         if let Some(field) = self.async_.as_ref() {
-            write!(writer, r#" async="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "async")?;
         }
         if let Some(field) = self.defer.as_ref() {
-            write!(writer, r#" defer="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "defer")?;
         }
         if let Some(field) = self.crossorigin.as_ref() {
-            write!(writer, r#" crossorigin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "crossorigin")?;
         }
         if let Some(field) = self.integrity.as_ref() {
-            write!(writer, r#" integrity="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "integrity")?;
         }
         if let Some(field) = self.referrerpolicy.as_ref() {
-            write!(writer, r#" referrerpolicy="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "referrerpolicy")?;
         }
         if let Some(field) = self.blocking.as_ref() {
-            write!(writer, r#" blocking="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "blocking")?;
         }
         if let Some(field) = self.fetchpriority.as_ref() {
-            write!(writer, r#" fetchpriority="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "fetchpriority")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -68,7 +68,7 @@ impl crate::RenderElement for Script {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</script>")?;
+        write!(writer, "</{}>", "script")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/scripting/slot.rs
+++ b/crates/html-sys/src/scripting/slot.rs
@@ -1,6 +1,6 @@
-/// The HTML `<slot>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)
+/** The HTML `<slot>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)*/
 #[doc(alias = "slot")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct Slot {
 }
 impl crate::RenderElement for Slot {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<slot")?;
+        write!(writer, "{}<{}", "", "slot")?;
         if let Some(field) = self.name.as_ref() {
-            write!(writer, r#" name="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "name")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -23,7 +23,7 @@ impl crate::RenderElement for Slot {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</slot>")?;
+        write!(writer, "</{}>", "slot")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/scripting/template.rs
+++ b/crates/html-sys/src/scripting/template.rs
@@ -1,6 +1,6 @@
-/// The HTML `<template>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)
+/** The HTML `<template>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)*/
 #[doc(alias = "template")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -10,7 +10,7 @@ pub struct Template {
 }
 impl crate::RenderElement for Template {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<template")?;
+        write!(writer, "{}<{}", "", "template")?;
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
         write!(writer, ">")?;
@@ -18,7 +18,7 @@ impl crate::RenderElement for Template {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</template>")?;
+        write!(writer, "</{}>", "template")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/address.rs
+++ b/crates/html-sys/src/sections/address.rs
@@ -1,6 +1,6 @@
-/// The HTML `<address>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)
+/** The HTML `<address>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)*/
 #[doc(alias = "address")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct Address {
 }
 impl crate::RenderElement for Address {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<address")?;
+        write!(writer, "{}<{}", "", "address")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for Address {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</address>")?;
+        write!(writer, "</{}>", "address")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/article.rs
+++ b/crates/html-sys/src/sections/article.rs
@@ -1,6 +1,6 @@
-/// The HTML `<article>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)
+/** The HTML `<article>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)*/
 #[doc(alias = "article")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -72,93 +72,93 @@ pub struct Article {
 }
 impl crate::RenderElement for Article {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<article")?;
+        write!(writer, "{}<{}", "", "article")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -167,7 +167,7 @@ impl crate::RenderElement for Article {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</article>")?;
+        write!(writer, "</{}>", "article")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/aside.rs
+++ b/crates/html-sys/src/sections/aside.rs
@@ -1,6 +1,6 @@
-/// The HTML `<aside>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside)
+/** The HTML `<aside>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside)*/
 #[doc(alias = "aside")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -62,81 +62,81 @@ pub struct Aside {
 }
 impl crate::RenderElement for Aside {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<aside")?;
+        write!(writer, "{}<{}", "", "aside")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -145,7 +145,7 @@ impl crate::RenderElement for Aside {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</aside>")?;
+        write!(writer, "</{}>", "aside")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/body.rs
+++ b/crates/html-sys/src/sections/body.rs
@@ -1,6 +1,6 @@
-/// The HTML `<body>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)
+/** The HTML `<body>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)*/
 #[doc(alias = "body")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -54,69 +54,69 @@ pub struct Body {
 }
 impl crate::RenderElement for Body {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<body")?;
+        write!(writer, "{}<{}", "", "body")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -125,7 +125,7 @@ impl crate::RenderElement for Body {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</body>")?;
+        write!(writer, "</{}>", "body")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/footer.rs
+++ b/crates/html-sys/src/sections/footer.rs
@@ -1,6 +1,6 @@
-/// The HTML `<footer>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer)
+/** The HTML `<footer>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer)*/
 #[doc(alias = "footer")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -66,84 +66,84 @@ pub struct Footer {
 }
 impl crate::RenderElement for Footer {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<footer")?;
+        write!(writer, "{}<{}", "", "footer")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -152,7 +152,7 @@ impl crate::RenderElement for Footer {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</footer>")?;
+        write!(writer, "</{}>", "footer")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/h1.rs
+++ b/crates/html-sys/src/sections/h1.rs
@@ -1,6 +1,6 @@
-/// The HTML `<h1>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1)
+/** The HTML `<h1>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1)*/
 #[doc(alias = "h1")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct Heading1 {
 }
 impl crate::RenderElement for Heading1 {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<h1")?;
+        write!(writer, "{}<{}", "", "h1")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -165,7 +165,7 @@ impl crate::RenderElement for Heading1 {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</h1>")?;
+        write!(writer, "</{}>", "h1")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/h2.rs
+++ b/crates/html-sys/src/sections/h2.rs
@@ -1,6 +1,6 @@
-/// The HTML `<h2>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2)
+/** The HTML `<h2>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2)*/
 #[doc(alias = "h2")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct Heading2 {
 }
 impl crate::RenderElement for Heading2 {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<h2")?;
+        write!(writer, "{}<{}", "", "h2")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -165,7 +165,7 @@ impl crate::RenderElement for Heading2 {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</h2>")?;
+        write!(writer, "</{}>", "h2")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/h3.rs
+++ b/crates/html-sys/src/sections/h3.rs
@@ -1,6 +1,6 @@
-/// The HTML `<h3>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3)
+/** The HTML `<h3>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3)*/
 #[doc(alias = "h3")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct Heading3 {
 }
 impl crate::RenderElement for Heading3 {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<h3")?;
+        write!(writer, "{}<{}", "", "h3")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -165,7 +165,7 @@ impl crate::RenderElement for Heading3 {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</h3>")?;
+        write!(writer, "</{}>", "h3")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/h4.rs
+++ b/crates/html-sys/src/sections/h4.rs
@@ -1,6 +1,6 @@
-/// The HTML `<h4>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4)
+/** The HTML `<h4>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4)*/
 #[doc(alias = "h4")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct Heading4 {
 }
 impl crate::RenderElement for Heading4 {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<h4")?;
+        write!(writer, "{}<{}", "", "h4")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -165,7 +165,7 @@ impl crate::RenderElement for Heading4 {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</h4>")?;
+        write!(writer, "</{}>", "h4")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/h5.rs
+++ b/crates/html-sys/src/sections/h5.rs
@@ -1,6 +1,6 @@
-/// The HTML `<h5>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5)
+/** The HTML `<h5>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5)*/
 #[doc(alias = "h5")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct Heading5 {
 }
 impl crate::RenderElement for Heading5 {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<h5")?;
+        write!(writer, "{}<{}", "", "h5")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -165,7 +165,7 @@ impl crate::RenderElement for Heading5 {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</h5>")?;
+        write!(writer, "</{}>", "h5")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/h6.rs
+++ b/crates/html-sys/src/sections/h6.rs
@@ -1,6 +1,6 @@
-/// The HTML `<h6>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6)
+/** The HTML `<h6>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6)*/
 #[doc(alias = "h6")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct Heading6 {
 }
 impl crate::RenderElement for Heading6 {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<h6")?;
+        write!(writer, "{}<{}", "", "h6")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -165,7 +165,7 @@ impl crate::RenderElement for Heading6 {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</h6>")?;
+        write!(writer, "</{}>", "h6")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/header.rs
+++ b/crates/html-sys/src/sections/header.rs
@@ -1,6 +1,6 @@
-/// The HTML `<header>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header)
+/** The HTML `<header>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header)*/
 #[doc(alias = "header")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -66,84 +66,84 @@ pub struct Header {
 }
 impl crate::RenderElement for Header {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<header")?;
+        write!(writer, "{}<{}", "", "header")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -152,7 +152,7 @@ impl crate::RenderElement for Header {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</header>")?;
+        write!(writer, "</{}>", "header")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/hgroup.rs
+++ b/crates/html-sys/src/sections/hgroup.rs
@@ -1,6 +1,6 @@
-/// The HTML `<hgroup>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup)
+/** The HTML `<hgroup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup)*/
 #[doc(alias = "hgroup")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct HeadingGroup {
 }
 impl crate::RenderElement for HeadingGroup {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<hgroup")?;
+        write!(writer, "{}<{}", "", "hgroup")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for HeadingGroup {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</hgroup>")?;
+        write!(writer, "</{}>", "hgroup")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/nav.rs
+++ b/crates/html-sys/src/sections/nav.rs
@@ -1,6 +1,6 @@
-/// The HTML `<nav>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav)
+/** The HTML `<nav>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav)*/
 #[doc(alias = "nav")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,90 +70,90 @@ pub struct Navigation {
 }
 impl crate::RenderElement for Navigation {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<nav")?;
+        write!(writer, "{}<{}", "", "nav")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -162,7 +162,7 @@ impl crate::RenderElement for Navigation {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</nav>")?;
+        write!(writer, "</{}>", "nav")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/sections/section.rs
+++ b/crates/html-sys/src/sections/section.rs
@@ -1,6 +1,6 @@
-/// The HTML `<section>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)
+/** The HTML `<section>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)*/
 #[doc(alias = "section")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,90 +70,90 @@ pub struct Section {
 }
 impl crate::RenderElement for Section {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<section")?;
+        write!(writer, "{}<{}", "", "section")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -162,7 +162,7 @@ impl crate::RenderElement for Section {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</section>")?;
+        write!(writer, "</{}>", "section")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/caption.rs
+++ b/crates/html-sys/src/tables/caption.rs
@@ -1,6 +1,6 @@
-/// The HTML `<caption>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption)
+/** The HTML `<caption>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption)*/
 #[doc(alias = "caption")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -56,72 +56,72 @@ pub struct Caption {
 }
 impl crate::RenderElement for Caption {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<caption")?;
+        write!(writer, "{}<{}", "", "caption")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -130,7 +130,7 @@ impl crate::RenderElement for Caption {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</caption>")?;
+        write!(writer, "</{}>", "caption")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/col.rs
+++ b/crates/html-sys/src/tables/col.rs
@@ -1,6 +1,6 @@
-/// The HTML `<col>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col)
+/** The HTML `<col>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col)*/
 #[doc(alias = "col")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct TableColumn {
 }
 impl crate::RenderElement for TableColumn {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<col")?;
+        write!(writer, "{}<{}", "", "col")?;
         if let Some(field) = self.span.as_ref() {
-            write!(writer, r#" span="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "span")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/tables/colgroup.rs
+++ b/crates/html-sys/src/tables/colgroup.rs
@@ -1,6 +1,6 @@
-/// The HTML `<colgroup>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup)
+/** The HTML `<colgroup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup)*/
 #[doc(alias = "colgroup")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -12,9 +12,9 @@ pub struct TableColumnGroup {
 }
 impl crate::RenderElement for TableColumnGroup {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<colgroup")?;
+        write!(writer, "{}<{}", "", "colgroup")?;
         if let Some(field) = self.span.as_ref() {
-            write!(writer, r#" span="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "span")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -23,7 +23,7 @@ impl crate::RenderElement for TableColumnGroup {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</colgroup>")?;
+        write!(writer, "</{}>", "colgroup")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/table.rs
+++ b/crates/html-sys/src/tables/table.rs
@@ -1,6 +1,6 @@
-/// The HTML `<table>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)
+/** The HTML `<table>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)*/
 #[doc(alias = "table")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct Table {
 }
 impl crate::RenderElement for Table {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<table")?;
+        write!(writer, "{}<{}", "", "table")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for Table {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</table>")?;
+        write!(writer, "</{}>", "table")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/tbody.rs
+++ b/crates/html-sys/src/tables/tbody.rs
@@ -1,6 +1,6 @@
-/// The HTML `<tbody>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody)
+/** The HTML `<tbody>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody)*/
 #[doc(alias = "tbody")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct TableBody {
 }
 impl crate::RenderElement for TableBody {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<tbody")?;
+        write!(writer, "{}<{}", "", "tbody")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for TableBody {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</tbody>")?;
+        write!(writer, "</{}>", "tbody")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/td.rs
+++ b/crates/html-sys/src/tables/td.rs
@@ -1,6 +1,6 @@
-/// The HTML `<td>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)
+/** The HTML `<td>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)*/
 #[doc(alias = "td")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -128,177 +128,177 @@ pub struct TableCell {
 }
 impl crate::RenderElement for TableCell {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<td")?;
+        write!(writer, "{}<{}", "", "td")?;
         if let Some(field) = self.colspan.as_ref() {
-            write!(writer, r#" colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "colspan")?;
         }
         if let Some(field) = self.rowspan.as_ref() {
-            write!(writer, r#" rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "rowspan")?;
         }
         if let Some(field) = self.headers.as_ref() {
-            write!(writer, r#" headers="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "headers")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -307,7 +307,7 @@ impl crate::RenderElement for TableCell {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</td>")?;
+        write!(writer, "</{}>", "td")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/tfoot.rs
+++ b/crates/html-sys/src/tables/tfoot.rs
@@ -1,6 +1,6 @@
-/// The HTML `<tfoot>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot)
+/** The HTML `<tfoot>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot)*/
 #[doc(alias = "tfoot")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct TableFoot {
 }
 impl crate::RenderElement for TableFoot {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<tfoot")?;
+        write!(writer, "{}<{}", "", "tfoot")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for TableFoot {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</tfoot>")?;
+        write!(writer, "</{}>", "tfoot")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/th.rs
+++ b/crates/html-sys/src/tables/th.rs
@@ -1,6 +1,6 @@
-/// The HTML `<th>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)
+/** The HTML `<th>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)*/
 #[doc(alias = "th")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -132,183 +132,183 @@ pub struct TableHeader {
 }
 impl crate::RenderElement for TableHeader {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<th")?;
+        write!(writer, "{}<{}", "", "th")?;
         if let Some(field) = self.colspan.as_ref() {
-            write!(writer, r#" colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "colspan")?;
         }
         if let Some(field) = self.rowspan.as_ref() {
-            write!(writer, r#" rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "rowspan")?;
         }
         if let Some(field) = self.headers.as_ref() {
-            write!(writer, r#" headers="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "headers")?;
         }
         if let Some(field) = self.scope.as_ref() {
-            write!(writer, r#" scope="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "scope")?;
         }
         if let Some(field) = self.abbr.as_ref() {
-            write!(writer, r#" abbr="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "abbr")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -317,7 +317,7 @@ impl crate::RenderElement for TableHeader {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</th>")?;
+        write!(writer, "</{}>", "th")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/thead.rs
+++ b/crates/html-sys/src/tables/thead.rs
@@ -1,6 +1,6 @@
-/// The HTML `<thead>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead)
+/** The HTML `<thead>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead)*/
 #[doc(alias = "thead")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct TableHead {
 }
 impl crate::RenderElement for TableHead {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<thead")?;
+        write!(writer, "{}<{}", "", "thead")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for TableHead {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</thead>")?;
+        write!(writer, "</{}>", "thead")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/tables/tr.rs
+++ b/crates/html-sys/src/tables/tr.rs
@@ -1,6 +1,6 @@
-/// The HTML `<tr>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr)
+/** The HTML `<tr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr)*/
 #[doc(alias = "tr")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct TableRow {
 }
 impl crate::RenderElement for TableRow {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<tr")?;
+        write!(writer, "{}<{}", "", "tr")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for TableRow {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</tr>")?;
+        write!(writer, "</{}>", "tr")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/a.rs
+++ b/crates/html-sys/src/text/a.rs
@@ -1,6 +1,6 @@
-/// The HTML `<a>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
+/** The HTML `<a>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)*/
 #[doc(alias = "a")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -138,192 +138,192 @@ pub struct Anchor {
 }
 impl crate::RenderElement for Anchor {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<a")?;
+        write!(writer, "{}<{}", "", "a")?;
         if let Some(field) = self.href.as_ref() {
-            write!(writer, r#" href="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "href")?;
         }
         if let Some(field) = self.target.as_ref() {
-            write!(writer, r#" target="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "target")?;
         }
         if let Some(field) = self.download.as_ref() {
-            write!(writer, r#" download="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "download")?;
         }
         if let Some(field) = self.ping.as_ref() {
-            write!(writer, r#" ping="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "ping")?;
         }
         if let Some(field) = self.rel.as_ref() {
-            write!(writer, r#" rel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "rel")?;
         }
         if let Some(field) = self.hreflang.as_ref() {
-            write!(writer, r#" hreflang="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "hreflang")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.referrerpolicy.as_ref() {
-            write!(writer, r#" referrerpolicy="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "referrerpolicy")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -332,7 +332,7 @@ impl crate::RenderElement for Anchor {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</a>")?;
+        write!(writer, "</{}>", "a")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/abbr.rs
+++ b/crates/html-sys/src/text/abbr.rs
@@ -1,6 +1,6 @@
-/// The HTML `<abbr>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)
+/** The HTML `<abbr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)*/
 #[doc(alias = "abbr")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Abbreviation {
 }
 impl crate::RenderElement for Abbreviation {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<abbr")?;
+        write!(writer, "{}<{}", "", "abbr")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Abbreviation {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</abbr>")?;
+        write!(writer, "</{}>", "abbr")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/b.rs
+++ b/crates/html-sys/src/text/b.rs
@@ -1,6 +1,6 @@
-/// The HTML `<b>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b)
+/** The HTML `<b>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b)*/
 #[doc(alias = "b")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Bold {
 }
 impl crate::RenderElement for Bold {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<b")?;
+        write!(writer, "{}<{}", "", "b")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Bold {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</b>")?;
+        write!(writer, "</{}>", "b")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/bdi.rs
+++ b/crates/html-sys/src/text/bdi.rs
@@ -1,6 +1,6 @@
-/// The HTML `<bdi>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi)
+/** The HTML `<bdi>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi)*/
 #[doc(alias = "bdi")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct BidirectionalIsolate {
 }
 impl crate::RenderElement for BidirectionalIsolate {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<bdi")?;
+        write!(writer, "{}<{}", "", "bdi")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for BidirectionalIsolate {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</bdi>")?;
+        write!(writer, "</{}>", "bdi")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/bdo.rs
+++ b/crates/html-sys/src/text/bdo.rs
@@ -1,6 +1,6 @@
-/// The HTML `<bdo>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo)
+/** The HTML `<bdo>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo)*/
 #[doc(alias = "bdo")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct BidirectionalTextOverride {
 }
 impl crate::RenderElement for BidirectionalTextOverride {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<bdo")?;
+        write!(writer, "{}<{}", "", "bdo")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for BidirectionalTextOverride {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</bdo>")?;
+        write!(writer, "</{}>", "bdo")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/blockquote.rs
+++ b/crates/html-sys/src/text/blockquote.rs
@@ -1,6 +1,6 @@
-/// The HTML `<blockquote>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)
+/** The HTML `<blockquote>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)*/
 #[doc(alias = "blockquote")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -124,171 +124,171 @@ pub struct BlockQuote {
 }
 impl crate::RenderElement for BlockQuote {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<blockquote")?;
+        write!(writer, "{}<{}", "", "blockquote")?;
         if let Some(field) = self.cite.as_ref() {
-            write!(writer, r#" cite="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "cite")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -297,7 +297,7 @@ impl crate::RenderElement for BlockQuote {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</blockquote>")?;
+        write!(writer, "</{}>", "blockquote")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/br.rs
+++ b/crates/html-sys/src/text/br.rs
@@ -1,6 +1,6 @@
-/// The HTML `<br>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br)
+/** The HTML `<br>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br)*/
 #[doc(alias = "br")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -14,12 +14,12 @@ pub struct LineBreak {
 }
 impl crate::RenderElement for LineBreak {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<br")?;
+        write!(writer, "{}<{}", "", "br")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/text/cite.rs
+++ b/crates/html-sys/src/text/cite.rs
@@ -1,6 +1,6 @@
-/// The HTML `<cite>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)
+/** The HTML `<cite>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)*/
 #[doc(alias = "cite")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Cite {
 }
 impl crate::RenderElement for Cite {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<cite")?;
+        write!(writer, "{}<{}", "", "cite")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Cite {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</cite>")?;
+        write!(writer, "</{}>", "cite")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/code.rs
+++ b/crates/html-sys/src/text/code.rs
@@ -1,6 +1,6 @@
-/// The HTML `<code>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)
+/** The HTML `<code>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)*/
 #[doc(alias = "code")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Code {
 }
 impl crate::RenderElement for Code {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<code")?;
+        write!(writer, "{}<{}", "", "code")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Code {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</code>")?;
+        write!(writer, "</{}>", "code")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/data.rs
+++ b/crates/html-sys/src/text/data.rs
@@ -1,6 +1,6 @@
-/// The HTML `<data>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data)
+/** The HTML `<data>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data)*/
 #[doc(alias = "data")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -118,162 +118,162 @@ pub struct Data {
 }
 impl crate::RenderElement for Data {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<data")?;
+        write!(writer, "{}<{}", "", "data")?;
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -282,7 +282,7 @@ impl crate::RenderElement for Data {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</data>")?;
+        write!(writer, "</{}>", "data")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/dd.rs
+++ b/crates/html-sys/src/text/dd.rs
@@ -1,6 +1,6 @@
-/// The HTML `<dd>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd)
+/** The HTML `<dd>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd)*/
 #[doc(alias = "dd")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -62,81 +62,81 @@ pub struct DescriptionDetails {
 }
 impl crate::RenderElement for DescriptionDetails {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<dd")?;
+        write!(writer, "{}<{}", "", "dd")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -145,7 +145,7 @@ impl crate::RenderElement for DescriptionDetails {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</dd>")?;
+        write!(writer, "</{}>", "dd")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/dfn.rs
+++ b/crates/html-sys/src/text/dfn.rs
@@ -1,6 +1,6 @@
-/// The HTML `<dfn>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn)
+/** The HTML `<dfn>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn)*/
 #[doc(alias = "dfn")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct Definition {
 }
 impl crate::RenderElement for Definition {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<dfn")?;
+        write!(writer, "{}<{}", "", "dfn")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for Definition {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</dfn>")?;
+        write!(writer, "</{}>", "dfn")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/div.rs
+++ b/crates/html-sys/src/text/div.rs
@@ -1,6 +1,6 @@
-/// The HTML `<div>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div)
+/** The HTML `<div>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div)*/
 #[doc(alias = "div")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Division {
 }
 impl crate::RenderElement for Division {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<div")?;
+        write!(writer, "{}<{}", "", "div")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Division {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</div>")?;
+        write!(writer, "</{}>", "div")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/dl.rs
+++ b/crates/html-sys/src/text/dl.rs
@@ -1,6 +1,6 @@
-/// The HTML `<dl>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl)
+/** The HTML `<dl>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl)*/
 #[doc(alias = "dl")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -66,84 +66,84 @@ pub struct DescriptionList {
 }
 impl crate::RenderElement for DescriptionList {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<dl")?;
+        write!(writer, "{}<{}", "", "dl")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -152,7 +152,7 @@ impl crate::RenderElement for DescriptionList {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</dl>")?;
+        write!(writer, "</{}>", "dl")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/dt.rs
+++ b/crates/html-sys/src/text/dt.rs
@@ -1,6 +1,6 @@
-/// The HTML `<dt>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt)
+/** The HTML `<dt>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt)*/
 #[doc(alias = "dt")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -66,87 +66,87 @@ pub struct DescriptionTerm {
 }
 impl crate::RenderElement for DescriptionTerm {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<dt")?;
+        write!(writer, "{}<{}", "", "dt")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -155,7 +155,7 @@ impl crate::RenderElement for DescriptionTerm {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</dt>")?;
+        write!(writer, "</{}>", "dt")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/em.rs
+++ b/crates/html-sys/src/text/em.rs
@@ -1,6 +1,6 @@
-/// The HTML `<em>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)
+/** The HTML `<em>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)*/
 #[doc(alias = "em")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Emphasis {
 }
 impl crate::RenderElement for Emphasis {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<em")?;
+        write!(writer, "{}<{}", "", "em")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Emphasis {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</em>")?;
+        write!(writer, "</{}>", "em")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/figcaption.rs
+++ b/crates/html-sys/src/text/figcaption.rs
@@ -1,6 +1,6 @@
-/// The HTML `<figcaption>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)
+/** The HTML `<figcaption>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)*/
 #[doc(alias = "figcaption")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -60,75 +60,75 @@ pub struct FigureCaption {
 }
 impl crate::RenderElement for FigureCaption {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<figcaption")?;
+        write!(writer, "{}<{}", "", "figcaption")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -137,7 +137,7 @@ impl crate::RenderElement for FigureCaption {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</figcaption>")?;
+        write!(writer, "</{}>", "figcaption")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/figure.rs
+++ b/crates/html-sys/src/text/figure.rs
@@ -1,6 +1,6 @@
-/// The HTML `<figure>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)
+/** The HTML `<figure>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)*/
 #[doc(alias = "figure")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct Figure {
 }
 impl crate::RenderElement for Figure {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<figure")?;
+        write!(writer, "{}<{}", "", "figure")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for Figure {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</figure>")?;
+        write!(writer, "</{}>", "figure")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/hr.rs
+++ b/crates/html-sys/src/text/hr.rs
@@ -1,6 +1,6 @@
-/// The HTML `<hr>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)
+/** The HTML `<hr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)*/
 #[doc(alias = "hr")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -70,93 +70,93 @@ pub struct ThematicBreak {
 }
 impl crate::RenderElement for ThematicBreak {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<hr")?;
+        write!(writer, "{}<{}", "", "hr")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/text/i.rs
+++ b/crates/html-sys/src/text/i.rs
@@ -1,6 +1,6 @@
-/// The HTML `<i>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i)
+/** The HTML `<i>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i)*/
 #[doc(alias = "i")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Italic {
 }
 impl crate::RenderElement for Italic {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<i")?;
+        write!(writer, "{}<{}", "", "i")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Italic {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</i>")?;
+        write!(writer, "</{}>", "i")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/kbd.rs
+++ b/crates/html-sys/src/text/kbd.rs
@@ -1,6 +1,6 @@
-/// The HTML `<kbd>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)
+/** The HTML `<kbd>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)*/
 #[doc(alias = "kbd")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct KeyboardInput {
 }
 impl crate::RenderElement for KeyboardInput {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<kbd")?;
+        write!(writer, "{}<{}", "", "kbd")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for KeyboardInput {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</kbd>")?;
+        write!(writer, "</{}>", "kbd")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/li.rs
+++ b/crates/html-sys/src/text/li.rs
@@ -1,6 +1,6 @@
-/// The HTML `<li>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li)
+/** The HTML `<li>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li)*/
 #[doc(alias = "li")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -124,171 +124,171 @@ pub struct ListItem {
 }
 impl crate::RenderElement for ListItem {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<li")?;
+        write!(writer, "{}<{}", "", "li")?;
         if let Some(field) = self.value.as_ref() {
-            write!(writer, r#" value="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "value")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -297,7 +297,7 @@ impl crate::RenderElement for ListItem {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</li>")?;
+        write!(writer, "</{}>", "li")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/main.rs
+++ b/crates/html-sys/src/text/main.rs
@@ -1,6 +1,6 @@
-/// The HTML `<main>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main)
+/** The HTML `<main>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main)*/
 #[doc(alias = "main")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -62,81 +62,81 @@ pub struct Main {
 }
 impl crate::RenderElement for Main {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<main")?;
+        write!(writer, "{}<{}", "", "main")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -145,7 +145,7 @@ impl crate::RenderElement for Main {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</main>")?;
+        write!(writer, "</{}>", "main")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/mark.rs
+++ b/crates/html-sys/src/text/mark.rs
@@ -1,6 +1,6 @@
-/// The HTML `<mark>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)
+/** The HTML `<mark>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)*/
 #[doc(alias = "mark")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct MarkText {
 }
 impl crate::RenderElement for MarkText {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<mark")?;
+        write!(writer, "{}<{}", "", "mark")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for MarkText {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</mark>")?;
+        write!(writer, "</{}>", "mark")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/menu.rs
+++ b/crates/html-sys/src/text/menu.rs
@@ -1,6 +1,6 @@
-/// The HTML `<menu>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu)
+/** The HTML `<menu>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu)*/
 #[doc(alias = "menu")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -76,99 +76,99 @@ pub struct Menu {
 }
 impl crate::RenderElement for Menu {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<menu")?;
+        write!(writer, "{}<{}", "", "menu")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -177,7 +177,7 @@ impl crate::RenderElement for Menu {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</menu>")?;
+        write!(writer, "</{}>", "menu")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/ol.rs
+++ b/crates/html-sys/src/text/ol.rs
@@ -1,6 +1,6 @@
-/// The HTML `<ol>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol)
+/** The HTML `<ol>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol)*/
 #[doc(alias = "ol")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -82,108 +82,108 @@ pub struct OrderedList {
 }
 impl crate::RenderElement for OrderedList {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<ol")?;
+        write!(writer, "{}<{}", "", "ol")?;
         if let Some(field) = self.reversed.as_ref() {
-            write!(writer, r#" reversed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "reversed")?;
         }
         if let Some(field) = self.start.as_ref() {
-            write!(writer, r#" start="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "start")?;
         }
         if let Some(field) = self.type_.as_ref() {
-            write!(writer, r#" type="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "type")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -192,7 +192,7 @@ impl crate::RenderElement for OrderedList {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</ol>")?;
+        write!(writer, "</{}>", "ol")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/p.rs
+++ b/crates/html-sys/src/text/p.rs
@@ -1,6 +1,6 @@
-/// The HTML `<p>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)
+/** The HTML `<p>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)*/
 #[doc(alias = "p")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Paragraph {
 }
 impl crate::RenderElement for Paragraph {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<p")?;
+        write!(writer, "{}<{}", "", "p")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Paragraph {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</p>")?;
+        write!(writer, "</{}>", "p")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/pre.rs
+++ b/crates/html-sys/src/text/pre.rs
@@ -1,6 +1,6 @@
-/// The HTML `<pre>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)
+/** The HTML `<pre>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)*/
 #[doc(alias = "pre")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct PreformattedText {
 }
 impl crate::RenderElement for PreformattedText {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<pre")?;
+        write!(writer, "{}<{}", "", "pre")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for PreformattedText {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</pre>")?;
+        write!(writer, "</{}>", "pre")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/q.rs
+++ b/crates/html-sys/src/text/q.rs
@@ -1,6 +1,6 @@
-/// The HTML `<q>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)
+/** The HTML `<q>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)*/
 #[doc(alias = "q")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -118,162 +118,162 @@ pub struct Quotation {
 }
 impl crate::RenderElement for Quotation {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<q")?;
+        write!(writer, "{}<{}", "", "q")?;
         if let Some(field) = self.cite.as_ref() {
-            write!(writer, r#" cite="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "cite")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -282,7 +282,7 @@ impl crate::RenderElement for Quotation {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</q>")?;
+        write!(writer, "</{}>", "q")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/rp.rs
+++ b/crates/html-sys/src/text/rp.rs
@@ -1,6 +1,6 @@
-/// The HTML `<rp>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp)
+/** The HTML `<rp>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp)*/
 #[doc(alias = "rp")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct RubyFallbackParenthesis {
 }
 impl crate::RenderElement for RubyFallbackParenthesis {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<rp")?;
+        write!(writer, "{}<{}", "", "rp")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for RubyFallbackParenthesis {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</rp>")?;
+        write!(writer, "</{}>", "rp")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/rt.rs
+++ b/crates/html-sys/src/text/rt.rs
@@ -1,6 +1,6 @@
-/// The HTML `<rt>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt)
+/** The HTML `<rt>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt)*/
 #[doc(alias = "rt")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct RubyText {
 }
 impl crate::RenderElement for RubyText {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<rt")?;
+        write!(writer, "{}<{}", "", "rt")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for RubyText {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</rt>")?;
+        write!(writer, "</{}>", "rt")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/ruby.rs
+++ b/crates/html-sys/src/text/ruby.rs
@@ -1,6 +1,6 @@
-/// The HTML `<ruby>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby)
+/** The HTML `<ruby>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby)*/
 #[doc(alias = "ruby")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -122,168 +122,168 @@ pub struct RubyAnnotation {
 }
 impl crate::RenderElement for RubyAnnotation {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<ruby")?;
+        write!(writer, "{}<{}", "", "ruby")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -292,7 +292,7 @@ impl crate::RenderElement for RubyAnnotation {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</ruby>")?;
+        write!(writer, "</{}>", "ruby")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/s.rs
+++ b/crates/html-sys/src/text/s.rs
@@ -1,6 +1,6 @@
-/// The HTML `<s>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)
+/** The HTML `<s>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)*/
 #[doc(alias = "s")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct StrikeThrough {
 }
 impl crate::RenderElement for StrikeThrough {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<s")?;
+        write!(writer, "{}<{}", "", "s")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for StrikeThrough {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</s>")?;
+        write!(writer, "</{}>", "s")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/samp.rs
+++ b/crates/html-sys/src/text/samp.rs
@@ -1,6 +1,6 @@
-/// The HTML `<samp>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)
+/** The HTML `<samp>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)*/
 #[doc(alias = "samp")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct SampleOutput {
 }
 impl crate::RenderElement for SampleOutput {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<samp")?;
+        write!(writer, "{}<{}", "", "samp")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for SampleOutput {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</samp>")?;
+        write!(writer, "</{}>", "samp")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/search.rs
+++ b/crates/html-sys/src/text/search.rs
@@ -1,6 +1,6 @@
-/// The HTML `<search>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search)
+/** The HTML `<search>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search)*/
 #[doc(alias = "search")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -66,84 +66,84 @@ pub struct Search {
 }
 impl crate::RenderElement for Search {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<search")?;
+        write!(writer, "{}<{}", "", "search")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -152,7 +152,7 @@ impl crate::RenderElement for Search {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</search>")?;
+        write!(writer, "</{}>", "search")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/small.rs
+++ b/crates/html-sys/src/text/small.rs
@@ -1,6 +1,6 @@
-/// The HTML `<small>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)
+/** The HTML `<small>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)*/
 #[doc(alias = "small")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct SideComment {
 }
 impl crate::RenderElement for SideComment {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<small")?;
+        write!(writer, "{}<{}", "", "small")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for SideComment {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</small>")?;
+        write!(writer, "</{}>", "small")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/span.rs
+++ b/crates/html-sys/src/text/span.rs
@@ -1,6 +1,6 @@
-/// The HTML `<span>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+/** The HTML `<span>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)*/
 #[doc(alias = "span")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Span {
 }
 impl crate::RenderElement for Span {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<span")?;
+        write!(writer, "{}<{}", "", "span")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Span {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</span>")?;
+        write!(writer, "</{}>", "span")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/strong.rs
+++ b/crates/html-sys/src/text/strong.rs
@@ -1,6 +1,6 @@
-/// The HTML `<strong>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)
+/** The HTML `<strong>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)*/
 #[doc(alias = "strong")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Strong {
 }
 impl crate::RenderElement for Strong {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<strong")?;
+        write!(writer, "{}<{}", "", "strong")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Strong {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</strong>")?;
+        write!(writer, "</{}>", "strong")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/sub.rs
+++ b/crates/html-sys/src/text/sub.rs
@@ -1,6 +1,6 @@
-/// The HTML `<sub>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)
+/** The HTML `<sub>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)*/
 #[doc(alias = "sub")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct SubScript {
 }
 impl crate::RenderElement for SubScript {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<sub")?;
+        write!(writer, "{}<{}", "", "sub")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for SubScript {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</sub>")?;
+        write!(writer, "</{}>", "sub")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/sup.rs
+++ b/crates/html-sys/src/text/sup.rs
@@ -1,6 +1,6 @@
-/// The HTML `<sup>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)
+/** The HTML `<sup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)*/
 #[doc(alias = "sup")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct SuperScript {
 }
 impl crate::RenderElement for SuperScript {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<sup")?;
+        write!(writer, "{}<{}", "", "sup")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for SuperScript {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</sup>")?;
+        write!(writer, "</{}>", "sup")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/time.rs
+++ b/crates/html-sys/src/text/time.rs
@@ -1,6 +1,6 @@
-/// The HTML `<time>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
+/** The HTML `<time>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)*/
 #[doc(alias = "time")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -118,162 +118,162 @@ pub struct Time {
 }
 impl crate::RenderElement for Time {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<time")?;
+        write!(writer, "{}<{}", "", "time")?;
         if let Some(field) = self.date_time.as_ref() {
-            write!(writer, r#" datetime="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "datetime")?;
         }
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -282,7 +282,7 @@ impl crate::RenderElement for Time {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</time>")?;
+        write!(writer, "</{}>", "time")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/u.rs
+++ b/crates/html-sys/src/text/u.rs
@@ -1,6 +1,6 @@
-/// The HTML `<u>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u)
+/** The HTML `<u>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u)*/
 #[doc(alias = "u")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Underline {
 }
 impl crate::RenderElement for Underline {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<u")?;
+        write!(writer, "{}<{}", "", "u")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Underline {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</u>")?;
+        write!(writer, "</{}>", "u")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/ul.rs
+++ b/crates/html-sys/src/text/ul.rs
@@ -1,6 +1,6 @@
-/// The HTML `<ul>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul)
+/** The HTML `<ul>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul)*/
 #[doc(alias = "ul")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -76,99 +76,99 @@ pub struct UnorderedList {
 }
 impl crate::RenderElement for UnorderedList {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<ul")?;
+        write!(writer, "{}<{}", "", "ul")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_braille_label.as_ref() {
-            write!(writer, r#" aria-braillelabel="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-braillelabel")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_label.as_ref() {
-            write!(writer, r#" aria-label="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-label")?;
         }
         if let Some(field) = self.aria_labelled_by_elements.as_ref() {
-            write!(writer, r#" aria-labelledby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-labelledby")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -177,7 +177,7 @@ impl crate::RenderElement for UnorderedList {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</ul>")?;
+        write!(writer, "</{}>", "ul")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/var.rs
+++ b/crates/html-sys/src/text/var.rs
@@ -1,6 +1,6 @@
-/// The HTML `<var>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)
+/** The HTML `<var>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)*/
 #[doc(alias = "var")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -116,159 +116,159 @@ pub struct Variable {
 }
 impl crate::RenderElement for Variable {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<var")?;
+        write!(writer, "{}<{}", "", "var")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if let Some(field) = self.aria_active_descendant_element.as_ref() {
-            write!(writer, r#" aria-activedescendant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-activedescendant")?;
         }
         if self.aria_atomic {
-            write!(writer, r#" aria-atomic"#)?;
+            write!(writer, " {}", "aria-atomic")?;
         }
         if let Some(field) = self.aria_auto_complete.as_ref() {
-            write!(writer, r#" aria-autocomplete="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-autocomplete")?;
         }
         if let Some(field) = self.aria_braille_role_description.as_ref() {
-            write!(writer, r#" aria-brailleroledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-brailleroledescription")?;
         }
         if self.aria_busy {
-            write!(writer, r#" aria-busy"#)?;
+            write!(writer, " {}", "aria-busy")?;
         }
         if let Some(field) = self.aria_checked.as_ref() {
-            write!(writer, r#" aria-checked="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-checked")?;
         }
         if let Some(field) = self.aria_col_count.as_ref() {
-            write!(writer, r#" aria-colcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colcount")?;
         }
         if let Some(field) = self.aria_col_index.as_ref() {
-            write!(writer, r#" aria-colindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindex")?;
         }
         if let Some(field) = self.aria_col_index_text.as_ref() {
-            write!(writer, r#" aria-colindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colindextext")?;
         }
         if let Some(field) = self.aria_col_span.as_ref() {
-            write!(writer, r#" aria-colspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-colspan")?;
         }
         if let Some(field) = self.aria_controls_elements.as_ref() {
-            write!(writer, r#" aria-controls="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-controls")?;
         }
         if let Some(field) = self.aria_current.as_ref() {
-            write!(writer, r#" aria-current="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-current")?;
         }
         if let Some(field) = self.aria_described_by_elements.as_ref() {
-            write!(writer, r#" aria-describedby="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-describedby")?;
         }
         if let Some(field) = self.aria_description.as_ref() {
-            write!(writer, r#" aria-description="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-description")?;
         }
         if let Some(field) = self.aria_details_elements.as_ref() {
-            write!(writer, r#" aria-details="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-details")?;
         }
         if self.aria_disabled {
-            write!(writer, r#" aria-disabled"#)?;
+            write!(writer, " {}", "aria-disabled")?;
         }
         if let Some(field) = self.aria_drop_effect.as_ref() {
-            write!(writer, r#" aria-dropeffect="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-dropeffect")?;
         }
         if let Some(field) = self.aria_error_message_elements.as_ref() {
-            write!(writer, r#" aria-errormessage="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-errormessage")?;
         }
         if self.aria_expanded {
-            write!(writer, r#" aria-expanded"#)?;
+            write!(writer, " {}", "aria-expanded")?;
         }
         if let Some(field) = self.aria_flow_to_elements.as_ref() {
-            write!(writer, r#" aria-flowto="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-flowto")?;
         }
         if self.aria_grabbed {
-            write!(writer, r#" aria-grabbed"#)?;
+            write!(writer, " {}", "aria-grabbed")?;
         }
         if let Some(field) = self.aria_has_popup.as_ref() {
-            write!(writer, r#" aria-haspopup="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-haspopup")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         if let Some(field) = self.aria_invalid.as_ref() {
-            write!(writer, r#" aria-invalid="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-invalid")?;
         }
         if let Some(field) = self.aria_key_shortcuts.as_ref() {
-            write!(writer, r#" aria-keyshortcuts="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-keyshortcuts")?;
         }
         if let Some(field) = self.aria_level.as_ref() {
-            write!(writer, r#" aria-level="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-level")?;
         }
         if let Some(field) = self.aria_live.as_ref() {
-            write!(writer, r#" aria-live="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-live")?;
         }
         if self.aria_modal {
-            write!(writer, r#" aria-modal"#)?;
+            write!(writer, " {}", "aria-modal")?;
         }
         if self.aria_multi_line {
-            write!(writer, r#" aria-multiline"#)?;
+            write!(writer, " {}", "aria-multiline")?;
         }
         if self.aria_multi_selectable {
-            write!(writer, r#" aria-multiselectable"#)?;
+            write!(writer, " {}", "aria-multiselectable")?;
         }
         if let Some(field) = self.aria_orientation.as_ref() {
-            write!(writer, r#" aria-orientation="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-orientation")?;
         }
         if let Some(field) = self.aria_owns_elements.as_ref() {
-            write!(writer, r#" aria-owns="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-owns")?;
         }
         if let Some(field) = self.aria_placeholder.as_ref() {
-            write!(writer, r#" aria-placeholder="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-placeholder")?;
         }
         if let Some(field) = self.aria_pos_in_set.as_ref() {
-            write!(writer, r#" aria-posinset="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-posinset")?;
         }
         if let Some(field) = self.aria_pressed.as_ref() {
-            write!(writer, r#" aria-pressed="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-pressed")?;
         }
         if self.aria_read_only {
-            write!(writer, r#" aria-readonly"#)?;
+            write!(writer, " {}", "aria-readonly")?;
         }
         if let Some(field) = self.aria_relevant.as_ref() {
-            write!(writer, r#" aria-relevant="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-relevant")?;
         }
         if self.aria_required {
-            write!(writer, r#" aria-required"#)?;
+            write!(writer, " {}", "aria-required")?;
         }
         if let Some(field) = self.aria_role_description.as_ref() {
-            write!(writer, r#" aria-roledescription="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-roledescription")?;
         }
         if let Some(field) = self.aria_row_count.as_ref() {
-            write!(writer, r#" aria-rowcount="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowcount")?;
         }
         if let Some(field) = self.aria_row_index.as_ref() {
-            write!(writer, r#" aria-rowindex="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindex")?;
         }
         if let Some(field) = self.aria_row_index_text.as_ref() {
-            write!(writer, r#" aria-rowindextext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowindextext")?;
         }
         if let Some(field) = self.aria_row_span.as_ref() {
-            write!(writer, r#" aria-rowspan="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-rowspan")?;
         }
         if self.aria_selected {
-            write!(writer, r#" aria-selected"#)?;
+            write!(writer, " {}", "aria-selected")?;
         }
         if let Some(field) = self.aria_set_size.as_ref() {
-            write!(writer, r#" aria-setsize="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-setsize")?;
         }
         if let Some(field) = self.aria_sort.as_ref() {
-            write!(writer, r#" aria-sort="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-sort")?;
         }
         if let Some(field) = self.aria_value_max.as_ref() {
-            write!(writer, r#" aria-valuemax="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemax")?;
         }
         if let Some(field) = self.aria_value_min.as_ref() {
-            write!(writer, r#" aria-valuemin="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuemin")?;
         }
         if let Some(field) = self.aria_value_now.as_ref() {
-            write!(writer, r#" aria-valuenow="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuenow")?;
         }
         if let Some(field) = self.aria_value_text.as_ref() {
-            write!(writer, r#" aria-valuetext="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "aria-valuetext")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;
@@ -277,7 +277,7 @@ impl crate::RenderElement for Variable {
     }
     #[allow(unused_variables)]
     fn write_closing_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "</var>")?;
+        write!(writer, "</{}>", "var")?;
         Ok(())
     }
 }

--- a/crates/html-sys/src/text/wbr.rs
+++ b/crates/html-sys/src/text/wbr.rs
@@ -1,6 +1,6 @@
-/// The HTML `<wbr>` element
-///
-/// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)
+/** The HTML `<wbr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)*/
 #[doc(alias = "wbr")]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -14,12 +14,12 @@ pub struct LineBreakOpportunity {
 }
 impl crate::RenderElement for LineBreakOpportunity {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
-        write!(writer, "<wbr")?;
+        write!(writer, "{}<{}", "", "wbr")?;
         if let Some(field) = self.role.as_ref() {
-            write!(writer, r#" role="{field}""#)?;
+            write!(writer, r#" {}="{field}""#, "role")?;
         }
         if self.aria_hidden {
-            write!(writer, r#" aria-hidden"#)?;
+            write!(writer, " {}", "aria-hidden")?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html/src/generated/a.rs
+++ b/crates/html/src/generated/a.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<a>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
+    /** The HTML `<a>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)*/
     #[doc(alias = "a")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/abbr.rs
+++ b/crates/html/src/generated/abbr.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<abbr>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)
+    /** The HTML `<abbr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)*/
     #[doc(alias = "abbr")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/address.rs
+++ b/crates/html/src/generated/address.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<address>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)
+    /** The HTML `<address>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address)*/
     #[doc(alias = "address")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/area.rs
+++ b/crates/html/src/generated/area.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<area>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area)
+    /** The HTML `<area>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area)*/
     #[doc(alias = "area")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/article.rs
+++ b/crates/html/src/generated/article.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<article>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)
+    /** The HTML `<article>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)*/
     #[doc(alias = "article")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/aside.rs
+++ b/crates/html/src/generated/aside.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<aside>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside)
+    /** The HTML `<aside>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside)*/
     #[doc(alias = "aside")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/audio.rs
+++ b/crates/html/src/generated/audio.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<audio>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)
+    /** The HTML `<audio>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)*/
     #[doc(alias = "audio")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/b.rs
+++ b/crates/html/src/generated/b.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<b>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b)
+    /** The HTML `<b>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b)*/
     #[doc(alias = "b")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/base.rs
+++ b/crates/html/src/generated/base.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<base>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)
+    /** The HTML `<base>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base)*/
     #[doc(alias = "base")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/bdi.rs
+++ b/crates/html/src/generated/bdi.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<bdi>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi)
+    /** The HTML `<bdi>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi)*/
     #[doc(alias = "bdi")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/bdo.rs
+++ b/crates/html/src/generated/bdo.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<bdo>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo)
+    /** The HTML `<bdo>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo)*/
     #[doc(alias = "bdo")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/blockquote.rs
+++ b/crates/html/src/generated/blockquote.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<blockquote>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)
+    /** The HTML `<blockquote>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote)*/
     #[doc(alias = "blockquote")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/body.rs
+++ b/crates/html/src/generated/body.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<body>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)
+    /** The HTML `<body>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)*/
     #[doc(alias = "body")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/br.rs
+++ b/crates/html/src/generated/br.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<br>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br)
+    /** The HTML `<br>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br)*/
     #[doc(alias = "br")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/button.rs
+++ b/crates/html/src/generated/button.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<button>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)
+    /** The HTML `<button>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button)*/
     #[doc(alias = "button")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/canvas.rs
+++ b/crates/html/src/generated/canvas.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<canvas>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas)
+    /** The HTML `<canvas>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas)*/
     #[doc(alias = "canvas")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/caption.rs
+++ b/crates/html/src/generated/caption.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<caption>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption)
+    /** The HTML `<caption>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption)*/
     #[doc(alias = "caption")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/cite.rs
+++ b/crates/html/src/generated/cite.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<cite>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)
+    /** The HTML `<cite>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite)*/
     #[doc(alias = "cite")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/code.rs
+++ b/crates/html/src/generated/code.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<code>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)
+    /** The HTML `<code>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code)*/
     #[doc(alias = "code")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/col.rs
+++ b/crates/html/src/generated/col.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<col>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col)
+    /** The HTML `<col>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col)*/
     #[doc(alias = "col")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/colgroup.rs
+++ b/crates/html/src/generated/colgroup.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<colgroup>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup)
+    /** The HTML `<colgroup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup)*/
     #[doc(alias = "colgroup")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/data.rs
+++ b/crates/html/src/generated/data.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<data>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data)
+    /** The HTML `<data>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data)*/
     #[doc(alias = "data")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/datalist.rs
+++ b/crates/html/src/generated/datalist.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<datalist>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)
+    /** The HTML `<datalist>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist)*/
     #[doc(alias = "datalist")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/dd.rs
+++ b/crates/html/src/generated/dd.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<dd>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd)
+    /** The HTML `<dd>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd)*/
     #[doc(alias = "dd")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/del.rs
+++ b/crates/html/src/generated/del.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<del>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)
+    /** The HTML `<del>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del)*/
     #[doc(alias = "del")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/details.rs
+++ b/crates/html/src/generated/details.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<details>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)
+    /** The HTML `<details>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details)*/
     #[doc(alias = "details")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/dfn.rs
+++ b/crates/html/src/generated/dfn.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<dfn>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn)
+    /** The HTML `<dfn>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn)*/
     #[doc(alias = "dfn")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/dialog.rs
+++ b/crates/html/src/generated/dialog.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<dialog>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+    /** The HTML `<dialog>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)*/
     #[doc(alias = "dialog")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/div.rs
+++ b/crates/html/src/generated/div.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<div>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div)
+    /** The HTML `<div>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div)*/
     #[doc(alias = "div")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/dl.rs
+++ b/crates/html/src/generated/dl.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<dl>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl)
+    /** The HTML `<dl>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl)*/
     #[doc(alias = "dl")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/dt.rs
+++ b/crates/html/src/generated/dt.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<dt>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt)
+    /** The HTML `<dt>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt)*/
     #[doc(alias = "dt")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/em.rs
+++ b/crates/html/src/generated/em.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<em>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)
+    /** The HTML `<em>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em)*/
     #[doc(alias = "em")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/embed.rs
+++ b/crates/html/src/generated/embed.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<embed>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed)
+    /** The HTML `<embed>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed)*/
     #[doc(alias = "embed")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/fieldset.rs
+++ b/crates/html/src/generated/fieldset.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<fieldset>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset)
+    /** The HTML `<fieldset>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset)*/
     #[doc(alias = "fieldset")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/figcaption.rs
+++ b/crates/html/src/generated/figcaption.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<figcaption>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)
+    /** The HTML `<figcaption>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption)*/
     #[doc(alias = "figcaption")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/figure.rs
+++ b/crates/html/src/generated/figure.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<figure>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)
+    /** The HTML `<figure>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure)*/
     #[doc(alias = "figure")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/footer.rs
+++ b/crates/html/src/generated/footer.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<footer>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer)
+    /** The HTML `<footer>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer)*/
     #[doc(alias = "footer")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/form.rs
+++ b/crates/html/src/generated/form.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<form>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
+    /** The HTML `<form>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)*/
     #[doc(alias = "form")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/h1.rs
+++ b/crates/html/src/generated/h1.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<h1>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1)
+    /** The HTML `<h1>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1)*/
     #[doc(alias = "h1")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/h2.rs
+++ b/crates/html/src/generated/h2.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<h2>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2)
+    /** The HTML `<h2>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2)*/
     #[doc(alias = "h2")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/h3.rs
+++ b/crates/html/src/generated/h3.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<h3>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3)
+    /** The HTML `<h3>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3)*/
     #[doc(alias = "h3")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/h4.rs
+++ b/crates/html/src/generated/h4.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<h4>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4)
+    /** The HTML `<h4>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4)*/
     #[doc(alias = "h4")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/h5.rs
+++ b/crates/html/src/generated/h5.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<h5>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5)
+    /** The HTML `<h5>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5)*/
     #[doc(alias = "h5")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/h6.rs
+++ b/crates/html/src/generated/h6.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<h6>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6)
+    /** The HTML `<h6>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6)*/
     #[doc(alias = "h6")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/head.rs
+++ b/crates/html/src/generated/head.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<head>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)
+    /** The HTML `<head>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)*/
     #[doc(alias = "head")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/header.rs
+++ b/crates/html/src/generated/header.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<header>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header)
+    /** The HTML `<header>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header)*/
     #[doc(alias = "header")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/hgroup.rs
+++ b/crates/html/src/generated/hgroup.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<hgroup>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup)
+    /** The HTML `<hgroup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup)*/
     #[doc(alias = "hgroup")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/hr.rs
+++ b/crates/html/src/generated/hr.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<hr>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)
+    /** The HTML `<hr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)*/
     #[doc(alias = "hr")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/html.rs
+++ b/crates/html/src/generated/html.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<html>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)
+    /** The HTML `<html>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html)*/
     #[doc(alias = "html")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/i.rs
+++ b/crates/html/src/generated/i.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<i>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i)
+    /** The HTML `<i>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i)*/
     #[doc(alias = "i")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/iframe.rs
+++ b/crates/html/src/generated/iframe.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<iframe>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)
+    /** The HTML `<iframe>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)*/
     #[doc(alias = "iframe")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/img.rs
+++ b/crates/html/src/generated/img.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<img>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)
+    /** The HTML `<img>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)*/
     #[doc(alias = "img")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/input.rs
+++ b/crates/html/src/generated/input.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<input>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
+    /** The HTML `<input>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)*/
     #[doc(alias = "input")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/ins.rs
+++ b/crates/html/src/generated/ins.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<ins>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)
+    /** The HTML `<ins>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins)*/
     #[doc(alias = "ins")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/kbd.rs
+++ b/crates/html/src/generated/kbd.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<kbd>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)
+    /** The HTML `<kbd>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd)*/
     #[doc(alias = "kbd")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/label.rs
+++ b/crates/html/src/generated/label.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<label>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)
+    /** The HTML `<label>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)*/
     #[doc(alias = "label")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/legend.rs
+++ b/crates/html/src/generated/legend.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<legend>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend)
+    /** The HTML `<legend>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend)*/
     #[doc(alias = "legend")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/li.rs
+++ b/crates/html/src/generated/li.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<li>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li)
+    /** The HTML `<li>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li)*/
     #[doc(alias = "li")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/link.rs
+++ b/crates/html/src/generated/link.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<link>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)
+    /** The HTML `<link>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link)*/
     #[doc(alias = "link")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/main.rs
+++ b/crates/html/src/generated/main.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<main>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main)
+    /** The HTML `<main>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main)*/
     #[doc(alias = "main")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/map.rs
+++ b/crates/html/src/generated/map.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<map>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map)
+    /** The HTML `<map>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map)*/
     #[doc(alias = "map")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/mark.rs
+++ b/crates/html/src/generated/mark.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<mark>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)
+    /** The HTML `<mark>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)*/
     #[doc(alias = "mark")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/menu.rs
+++ b/crates/html/src/generated/menu.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<menu>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu)
+    /** The HTML `<menu>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu)*/
     #[doc(alias = "menu")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/meta.rs
+++ b/crates/html/src/generated/meta.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<meta>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)
+    /** The HTML `<meta>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)*/
     #[doc(alias = "meta")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/meter.rs
+++ b/crates/html/src/generated/meter.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<meter>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter)
+    /** The HTML `<meter>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter)*/
     #[doc(alias = "meter")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/nav.rs
+++ b/crates/html/src/generated/nav.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<nav>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav)
+    /** The HTML `<nav>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav)*/
     #[doc(alias = "nav")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/noscript.rs
+++ b/crates/html/src/generated/noscript.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<noscript>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)
+    /** The HTML `<noscript>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)*/
     #[doc(alias = "noscript")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/object.rs
+++ b/crates/html/src/generated/object.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<object>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object)
+    /** The HTML `<object>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object)*/
     #[doc(alias = "object")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/ol.rs
+++ b/crates/html/src/generated/ol.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<ol>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol)
+    /** The HTML `<ol>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol)*/
     #[doc(alias = "ol")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/optgroup.rs
+++ b/crates/html/src/generated/optgroup.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<optgroup>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup)
+    /** The HTML `<optgroup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup)*/
     #[doc(alias = "optgroup")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/option.rs
+++ b/crates/html/src/generated/option.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<option>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option)
+    /** The HTML `<option>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option)*/
     #[doc(alias = "option")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/output.rs
+++ b/crates/html/src/generated/output.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<output>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output)
+    /** The HTML `<output>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output)*/
     #[doc(alias = "output")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/p.rs
+++ b/crates/html/src/generated/p.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<p>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)
+    /** The HTML `<p>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)*/
     #[doc(alias = "p")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/picture.rs
+++ b/crates/html/src/generated/picture.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<picture>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)
+    /** The HTML `<picture>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture)*/
     #[doc(alias = "picture")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/pre.rs
+++ b/crates/html/src/generated/pre.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<pre>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)
+    /** The HTML `<pre>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre)*/
     #[doc(alias = "pre")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/progress.rs
+++ b/crates/html/src/generated/progress.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<progress>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress)
+    /** The HTML `<progress>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress)*/
     #[doc(alias = "progress")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/q.rs
+++ b/crates/html/src/generated/q.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<q>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)
+    /** The HTML `<q>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q)*/
     #[doc(alias = "q")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/rp.rs
+++ b/crates/html/src/generated/rp.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<rp>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp)
+    /** The HTML `<rp>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp)*/
     #[doc(alias = "rp")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/rt.rs
+++ b/crates/html/src/generated/rt.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<rt>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt)
+    /** The HTML `<rt>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt)*/
     #[doc(alias = "rt")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/ruby.rs
+++ b/crates/html/src/generated/ruby.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<ruby>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby)
+    /** The HTML `<ruby>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby)*/
     #[doc(alias = "ruby")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/s.rs
+++ b/crates/html/src/generated/s.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<s>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)
+    /** The HTML `<s>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s)*/
     #[doc(alias = "s")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/samp.rs
+++ b/crates/html/src/generated/samp.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<samp>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)
+    /** The HTML `<samp>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)*/
     #[doc(alias = "samp")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/script.rs
+++ b/crates/html/src/generated/script.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<script>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)
+    /** The HTML `<script>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)*/
     #[doc(alias = "script")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/search.rs
+++ b/crates/html/src/generated/search.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<search>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search)
+    /** The HTML `<search>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search)*/
     #[doc(alias = "search")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/section.rs
+++ b/crates/html/src/generated/section.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<section>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)
+    /** The HTML `<section>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)*/
     #[doc(alias = "section")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/select.rs
+++ b/crates/html/src/generated/select.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<select>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
+    /** The HTML `<select>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)*/
     #[doc(alias = "select")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/slot.rs
+++ b/crates/html/src/generated/slot.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<slot>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)
+    /** The HTML `<slot>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)*/
     #[doc(alias = "slot")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/small.rs
+++ b/crates/html/src/generated/small.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<small>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)
+    /** The HTML `<small>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small)*/
     #[doc(alias = "small")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/source.rs
+++ b/crates/html/src/generated/source.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<source>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
+    /** The HTML `<source>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)*/
     #[doc(alias = "source")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/span.rs
+++ b/crates/html/src/generated/span.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<span>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)
+    /** The HTML `<span>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span)*/
     #[doc(alias = "span")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/strong.rs
+++ b/crates/html/src/generated/strong.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<strong>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)
+    /** The HTML `<strong>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong)*/
     #[doc(alias = "strong")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/style.rs
+++ b/crates/html/src/generated/style.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<style>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)
+    /** The HTML `<style>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style)*/
     #[doc(alias = "style")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/sub.rs
+++ b/crates/html/src/generated/sub.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<sub>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)
+    /** The HTML `<sub>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub)*/
     #[doc(alias = "sub")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/summary.rs
+++ b/crates/html/src/generated/summary.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<summary>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary)
+    /** The HTML `<summary>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary)*/
     #[doc(alias = "summary")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/sup.rs
+++ b/crates/html/src/generated/sup.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<sup>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)
+    /** The HTML `<sup>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup)*/
     #[doc(alias = "sup")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/table.rs
+++ b/crates/html/src/generated/table.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<table>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)
+    /** The HTML `<table>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)*/
     #[doc(alias = "table")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/tbody.rs
+++ b/crates/html/src/generated/tbody.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<tbody>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody)
+    /** The HTML `<tbody>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody)*/
     #[doc(alias = "tbody")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/td.rs
+++ b/crates/html/src/generated/td.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<td>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)
+    /** The HTML `<td>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)*/
     #[doc(alias = "td")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/template.rs
+++ b/crates/html/src/generated/template.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<template>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)
+    /** The HTML `<template>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)*/
     #[doc(alias = "template")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/textarea.rs
+++ b/crates/html/src/generated/textarea.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<textarea>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
+    /** The HTML `<textarea>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)*/
     #[doc(alias = "textarea")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/tfoot.rs
+++ b/crates/html/src/generated/tfoot.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<tfoot>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot)
+    /** The HTML `<tfoot>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot)*/
     #[doc(alias = "tfoot")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/th.rs
+++ b/crates/html/src/generated/th.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<th>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)
+    /** The HTML `<th>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th)*/
     #[doc(alias = "th")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/thead.rs
+++ b/crates/html/src/generated/thead.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<thead>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead)
+    /** The HTML `<thead>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead)*/
     #[doc(alias = "thead")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/time.rs
+++ b/crates/html/src/generated/time.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<time>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
+    /** The HTML `<time>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)*/
     #[doc(alias = "time")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/title.rs
+++ b/crates/html/src/generated/title.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<title>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)
+    /** The HTML `<title>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title)*/
     #[doc(alias = "title")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/tr.rs
+++ b/crates/html/src/generated/tr.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<tr>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr)
+    /** The HTML `<tr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr)*/
     #[doc(alias = "tr")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/track.rs
+++ b/crates/html/src/generated/track.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<track>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track)
+    /** The HTML `<track>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track)*/
     #[doc(alias = "track")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/u.rs
+++ b/crates/html/src/generated/u.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<u>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u)
+    /** The HTML `<u>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u)*/
     #[doc(alias = "u")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/ul.rs
+++ b/crates/html/src/generated/ul.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<ul>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul)
+    /** The HTML `<ul>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul)*/
     #[doc(alias = "ul")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/var.rs
+++ b/crates/html/src/generated/var.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<var>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)
+    /** The HTML `<var>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var)*/
     #[doc(alias = "var")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/video.rs
+++ b/crates/html/src/generated/video.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<video>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)
+    /** The HTML `<video>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video)*/
     #[doc(alias = "video")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/crates/html/src/generated/wbr.rs
+++ b/crates/html/src/generated/wbr.rs
@@ -1,7 +1,7 @@
 pub mod element {
-    /// The HTML `<wbr>` element
-    ///
-    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)
+    /** The HTML `<wbr>` element
+
+ [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)*/
     #[doc(alias = "wbr")]
     #[non_exhaustive]
     #[derive(PartialEq, Clone, Default)]

--- a/xtask/src/generate.rs
+++ b/xtask/src/generate.rs
@@ -25,7 +25,7 @@ pub fn generate_sys() -> Result<()> {
             code.dir,
             code.filename
         );
-        std::fs::write(filename, code.code.as_bytes())?;
+        std::fs::write(filename, code.code()?.as_bytes())?;
     }
     Ok(())
 }
@@ -50,7 +50,7 @@ pub fn generate_html() -> Result<()> {
             code.dir,
             code.filename
         );
-        std::fs::write(filename, code.code.as_bytes())?;
+        std::fs::write(filename, code.code()?.as_bytes())?;
     }
     Ok(())
 }


### PR DESCRIPTION
This PR replaces `format!` with [`quote!`](https://docs.rs/quote) in `crates/html_bindgen/src/generate/`.
`CodeFile` has a `pub code: TokenStream` now, still `prettyplease`d.
Only `cargo xtask generate` was used.

All tests pass.

The generated code is almost identical. Exceptions:
- `/// Doc` -> `/** Doc */`
- `write!("foo")` -> `write!("{}", "foo")`

I am waiting for your feedback. I might redo #77, then go for #39.