### PR TITLE
Add ability to add the onsubmit field to a form.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "submodules/webref"]
 	path = submodules/webref
 	url = https://github.com/w3c/webref
+	branch = main

--- a/crates/html-sys/src/forms/button.rs
+++ b/crates/html-sys/src/forms/button.rs
@@ -127,6 +127,8 @@ pub struct Button {
     pub aria_value_min: std::option::Option<f64>,
     /// Defines the human readable text alternative of aria-valuenow for a range widget.
     pub aria_value_text: std::option::Option<std::borrow::Cow<'static, str>>,
+    /// The onclick attribute
+    pub onclick: std::option::Option<std::borrow::Cow<'static, str>>,
 }
 impl crate::RenderElement for Button {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
@@ -304,6 +306,9 @@ impl crate::RenderElement for Button {
         }
         if let Some(field) = self.aria_value_text.as_ref() {
             write!(writer, r#" aria-valuetext="{field}""#)?;
+        }
+        if let Some(field) = self.onclick.as_ref() {
+            write!(writer, r#" onclick="{field}""#)?;
         }
         write!(writer, "{}", self.global_attrs)?;
         write!(writer, "{}", self.data_map)?;

--- a/crates/html-sys/src/forms/form.rs
+++ b/crates/html-sys/src/forms/form.rs
@@ -7,6 +7,8 @@
 pub struct Form {
     pub data_map: crate::DataMap,
     global_attrs: crate::GlobalAttributes,
+    /// The onsubmit portion of a form
+    pub onsubmit: std::option::Option<std::borrow::Cow<'static, str>>,
     /// Character encodings to use for form submission
     pub accept_charset: std::option::Option<std::borrow::Cow<'static, str>>,
     /// URL to use for form submission
@@ -79,6 +81,9 @@ pub struct Form {
 impl crate::RenderElement for Form {
     fn write_opening_tag<W: std::fmt::Write>(&self, writer: &mut W) -> std::fmt::Result {
         write!(writer, "<form")?;
+        if let Some(field) = self.onsubmit.as_ref() {
+        	write!(writer, r#" onsubmit="{field}""#)?;
+        }
         if let Some(field) = self.accept_charset.as_ref() {
             write!(writer, r#" accept-charset="{field}""#)?;
         }

--- a/crates/html/src/generated/button.rs
+++ b/crates/html/src/generated/button.rs
@@ -108,6 +108,12 @@ pub mod element {
         ) {
             self.sys.name = value.map(|v| v.into());
         }
+        /// Set the value of the onclicked attribute
+        /// Set the value of the `onsubmit` attribute
+        pub fn set_onclick(&mut self, value: std::option::Option<impl Into<std::borrow::Cow<'static, str>>>,
+        ) {
+            self.sys.onclick = value.map(|v| v.into());
+        }
         /// Get the value of the `popovertarget` attribute
         pub fn popovertarget(&self) -> std::option::Option<&str> {
             self.sys.popovertarget.as_deref()
@@ -2010,6 +2016,11 @@ pub mod builder {
             (f)(&mut ty_builder);
             let ty = ty_builder.build();
             self.element.children_mut().push(ty.into());
+            self
+        }
+        /// Set the onclick attribute
+        pub fn onclick(&mut self, value: impl Into<std::borrow::Cow<'static, str>>) -> &mut Self {
+            self.element.set_onclick(Some(value.into()));
             self
         }
         /// Append a new `Output` element

--- a/crates/html/src/generated/form.rs
+++ b/crates/html/src/generated/form.rs
@@ -48,6 +48,11 @@ pub mod element {
         ) {
             self.sys.action = value.map(|v| v.into());
         }
+        /// Set the value of the `onsubmit` attribute
+        pub fn set_onsubmit(&mut self, value: std::option::Option<impl Into<std::borrow::Cow<'static, str>>>,
+        ) {
+            self.sys.onsubmit = value.map(|v| v.into());
+        }
         /// Get the value of the `autocomplete` attribute
         pub fn autocomplete(&self) -> std::option::Option<&str> {
             self.sys.autocomplete.as_deref()
@@ -1552,6 +1557,11 @@ pub mod builder {
         /// Finish building the element
         pub fn build(&mut self) -> super::element::Form {
             self.element.clone()
+        }
+        /// Set the onsubmit property
+        pub fn onsubmit(&mut self, value: impl Into<std::borrow::Cow<'static, str>>) -> &mut FormBuilder {
+        	self.element.set_onsubmit(Some(value.into()));
+        	self
         }
         /// Insert a `data-*` property
         pub fn data(


### PR DESCRIPTION
The formbuilder is missing a way to set the onsubmit parameter. See [this link](https://www.w3schools.com/tags/ev_onsubmit.asp) for more information.
