### PR TITLE
Expand scraping and parsing to include GlobalEventHandlers

### DIFF
--- a/crates/html-bindgen/src/generate/html/mod.rs
+++ b/crates/html-bindgen/src/generate/html/mod.rs
@@ -211,17 +211,30 @@ fn generate_element(el: MergedElement, global_attributes: &[Attribute]) -> Resul
     "#
     );
 
+    let usages = format!(
+        "
+        use crate::EventHandler;
+        use crate::OnErrorEventHandler;
+        use crate::OnBeforeUnloadEventHandler;
+        use crate::MediaProvider;
+        "
+    );
+
     let code = format!(
         "
+
         pub mod element {{
+            {usages}
             {element}
         }}
 
         pub mod child {{
+            {usages}
             {children_enum}
         }}
 
         pub mod builder {{
+            {usages}
             {builder}
         }}
     "
@@ -547,6 +560,7 @@ fn gen_methods(struct_name: &str, attributes: &[Attribute]) -> String {
         let return_ty = match &attr.ty {
             AttributeType::Bool => "bool".to_owned(),
             AttributeType::String => "std::option::Option<&str>".to_owned(),
+            AttributeType::Identifier(i) => format!("&std::option::Option<{i}>"),
             ty => format!("std::option::Option<{ty}>"),
         };
 
@@ -555,6 +569,7 @@ fn gen_methods(struct_name: &str, attributes: &[Attribute]) -> String {
             AttributeType::String => {
                 "std::option::Option<impl Into<std::borrow::Cow<'static, str>>>".to_owned()
             }
+            AttributeType::Identifier(i) => format!("std::option::Option<{i}>"),
             ty => format!("std::option::Option<{ty}>"),
         };
 
@@ -566,7 +581,7 @@ fn gen_methods(struct_name: &str, attributes: &[Attribute]) -> String {
                 format!("self.sys.{field_name}.as_deref()")
             }
             AttributeType::Identifier(i) => {
-                format!("self.sys.{field_name}.as_deref()")
+                format!("&self.sys.{field_name}")
             }
             _ => todo!("unhandled type"),
         };

--- a/crates/html-bindgen/src/generate/html/mod.rs
+++ b/crates/html-bindgen/src/generate/html/mod.rs
@@ -565,6 +565,9 @@ fn gen_methods(struct_name: &str, attributes: &[Attribute]) -> String {
             AttributeType::String => {
                 format!("self.sys.{field_name}.as_deref()")
             }
+            AttributeType::Identifier(i) => {
+                format!("self.sys.{field_name}.as_deref()")
+            }
             _ => todo!("unhandled type"),
         };
         let field_setter = match &attr.ty {

--- a/crates/html-bindgen/src/generate/sys/mod.rs
+++ b/crates/html-bindgen/src/generate/sys/mod.rs
@@ -8,6 +8,12 @@ use crate::{utils, Result};
 use indoc::{formatdoc, writedoc};
 
 const INCLUDES: &str = r##"
+
+pub type EventHandler = String;
+pub type OnErrorEventHandler = String;
+pub type MediaProvider = String;
+pub type OnBeforeUnloadEventHandler = String;
+
 /// Render an element to a writer.
 pub trait RenderElement {
     /// Write the opening tag to a writer.
@@ -144,6 +150,9 @@ fn generate_element(el: MergedElement) -> Result<CodeFile> {
 
     let filename = format!("{}.rs", tag_name);
     let fields = generate_fields(&attributes);
+
+    let use_items = "use crate::EventHandler;\nuse crate::OnErrorEventHandler;\nuse crate::OnBeforeUnloadEventHandler;use crate::MediaProvider;\n".to_string();
+
     let opening_tag_content = generate_opening_tag(&attributes, &tag_name, has_global_attributes);
     let closing_tag_content = generate_closing_tag(&tag_name, has_closing_tag);
 
@@ -156,6 +165,9 @@ fn generate_element(el: MergedElement) -> Result<CodeFile> {
         r#"/// The HTML `<{tag_name}>` element
         ///
         /// [MDN Documentation]({mdn_link})
+        
+        {use_items}
+
         #[doc(alias = "{tag_name}")]
         #[non_exhaustive]
         #[derive(Debug, Clone, PartialEq, Default)]

--- a/crates/html-bindgen/src/generate/sys/mod.rs
+++ b/crates/html-bindgen/src/generate/sys/mod.rs
@@ -297,7 +297,11 @@ fn generate_attribute_display(attr: &Attribute) -> String {
                 write!(writer, r#" {name}="{{field}}""#)?;
             }}"##
         ),
-        AttributeType::Identifier(_) => todo!(),
+        AttributeType::Identifier(i) => format!(
+            r##"if let Some(field) = self.{field_name}.as_ref() {{
+                write!(writer, r#" {name}="{{field}}""#)?;
+            }}"##
+        ),
         AttributeType::Enumerable(_) => todo!(),
     }
 }

--- a/crates/html-bindgen/src/merge/mod.rs
+++ b/crates/html-bindgen/src/merge/mod.rs
@@ -314,9 +314,7 @@ fn merge_attributes(
         .collect::<HashMap<String, _>>();
     for (name, interface) in interfaces.iter() {
         if !interface.includes.is_empty() {
-            eprintln!("Need to include interface attributes for {}", name);
             for include in interface.includes.iter() {
-                eprintln!("\tINCLUDE {}", include);
                 if let Some(include_me) = interfaces.get(include) {
                     if let Some(imap) = interface_map.get_mut(name) {
                         if !include_me.includes.is_empty() {
@@ -335,13 +333,6 @@ fn merge_attributes(
         }
     }
 
-    for (k, hm) in interface_map.iter() {
-        eprintln!("Interface {}", k);
-        for (n, attr) in hm.iter() {
-            eprintln!("\t {} {:?}", n, attr);
-        }
-    }
-
     // From https://www.w3.org/TR/role-attribute/
     let role_attr = Attribute {
         name: "role".to_owned(),
@@ -354,15 +345,12 @@ fn merge_attributes(
 
     for el in elements.values() {
         let vec = output.entry(el.struct_name.clone()).or_default();
-        eprintln!("Checking for interface {} for {}", el.dom_interface, el.struct_name);
 
         let mut interfaces = vec![el.dom_interface.to_owned()];
         if !el.dom_name.is_empty() && el.dom_name != el.dom_interface {
-            eprintln!("Pushing dom interface {}", el.dom_name);
             interfaces.push(el.dom_name.clone());
         }
         if let Some(i) = &el.dom_base {
-            eprintln!("Pushing dom base {}", i);
             interfaces.push(i.clone());
         }
         for i in el.includes.iter() {
@@ -370,12 +358,10 @@ fn merge_attributes(
         }
 
         for interface in interfaces {
-            eprintln!("\tAdding attributes from {}", interface);
             match interface_map.get(&interface) {
                 Some(interfacemap) => {
                     for (name, attr) in interfacemap {
                         if !vec.contains(attr) {
-                            eprintln!("ATTRIBUTE 7 is {} {} {:?}", interface, name, attr);
                             vec.push(attr.to_owned());
                         }
                     }

--- a/crates/html-bindgen/src/merge/mod.rs
+++ b/crates/html-bindgen/src/merge/mod.rs
@@ -361,15 +361,43 @@ fn merge_attributes(
             match interface_map.get(&interface) {
                 Some(interfacemap) => {
                     for (name, attr) in interfacemap {
-                        if !vec.contains(attr) {
+                        let mut contains = false;
+                        let mut existing = None;
+                        for a in vec.iter() {
+                            let a: &Attribute = a;
+                            if a.name == attr.name {
+                                contains = true;
+                                existing = Some(a);
+                                break;
+                            }
+                        }
+                        if !contains {
+                            eprintln!("Adding attribute 9 {} {:?}", name, attr);
                             vec.push(attr.to_owned());
+                        }
+                        else {
+                            eprintln!("Skipping attribute {} {:?} because of {:?}", name, attr, existing);
                         }
                     }
                 }
                 None => {
                     for v in el.attributes.iter() {
-                        if !vec.contains(v) {
+                        let mut contains = false;
+                        let mut existing = None;
+                        for a in vec.iter() {
+                            let a: &Attribute = a;
+                            if a.name == v.name {
+                                contains = true;
+                                existing = Some(a);
+                                break;
+                            }
+                        }
+                        if !contains {
+                            eprintln!("Adding attribute 8 {:?}", v);
                             vec.push(v.to_owned());
+                        }
+                        else {
+                            eprintln!("Skipping attribute {:?} because fo {:?}", v, existing);
                         }
                     }
                 }

--- a/crates/html-bindgen/src/parse/elements/mod.rs
+++ b/crates/html-bindgen/src/parse/elements/mod.rs
@@ -308,10 +308,6 @@ fn append_super_categories(cat_output: &mut Vec<ParsedRelationship>) {
 
 /// Find out which WebIDL interface this element relies on.
 fn parse_dom_interface(lines: &[String]) -> String {
-    eprintln!("PARSE DOM:");
-    for s in lines.iter() {
-        eprintln!("\t{}", s);
-    }
     let line = lines.get(0).as_deref().unwrap().clone();
 
     if line.starts_with("Uses") {

--- a/crates/html-bindgen/src/parse/mod.rs
+++ b/crates/html-bindgen/src/parse/mod.rs
@@ -39,7 +39,7 @@ impl Display for AttributeType {
             AttributeType::String => write!(f, "String"),
             AttributeType::Integer => write!(f, "i64"),
             AttributeType::Float => write!(f, "f64"),
-            AttributeType::Identifier(_) => todo!("identifier attr not yet implemented"),
+            AttributeType::Identifier(i) => write!(f, "{}", i),
             AttributeType::Enumerable(_) => todo!("enum attr not yet implemented"),
         }
     }

--- a/crates/html-bindgen/src/parse/webidls.rs
+++ b/crates/html-bindgen/src/parse/webidls.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use super::{Attribute, AttributeType};
@@ -5,6 +6,7 @@ use crate::Result;
 use convert_case::{Case, Casing};
 use serde::{Deserialize, Serialize};
 use weedle::interface::InterfaceMember;
+use weedle::mixin::MixinMember;
 
 /// The parsed WebIDL definitions converted from the raw spec.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,41 +14,97 @@ pub struct ParsedInterface {
     pub name: String,
     pub inherits_from: Option<String>,
     pub attributes: Vec<Attribute>,
+    pub includes: Vec<String>,
 }
 
 pub fn parse_webidls(
     iter: impl Iterator<Item = Result<(String, PathBuf)>>,
 ) -> Result<Vec<ParsedInterface>> {
-    let mut outputs = vec![];
+    let mut interfacemap = HashMap::new();
+    let mut includes : Vec<(String, String)> = Vec::new();
     for res in iter {
         let (string, path) = res?;
         let filename = path.file_name().unwrap().to_str().unwrap();
-        if !filename.starts_with("HTML") {
+        let mut parse = filename.starts_with("HTML");
+        match filename {
+            "GlobalEventHandlers.webidl" |
+            "Element.webidl" => parse = true,
+            _ => {}
+        }
+        if !parse {
             continue;
         }
         let string = string.trim();
         let definitions = weedle::parse(&string).map_err(|err| err.to_string())?;
         let definitions = definitions.into_iter();
         for def in definitions {
-            if let weedle::Definition::Interface(interface) = def {
-                outputs.push(ParsedInterface {
-                    name: parse_interface_name(&interface),
-                    inherits_from: parse_inheritance(&interface),
-                    attributes: interface
+            match def {
+                weedle::Definition::Interface(interface) => {
+                    eprintln!("INTERFACE INFO {} IS {:?}", parse_interface_name(&interface), interface.inheritance);
+                    interfacemap.insert(parse_interface_name(&interface), ParsedInterface {
+                        name: parse_interface_name(&interface),
+                        inherits_from: parse_inheritance(&interface),
+                        attributes: interface
                         .members
                         .body
                         .iter()
                         .filter_map(parse_attributes)
                         .collect::<Vec<_>>(),
-                });
+                        includes: Vec::new(),
+                    });
+                }
+                weedle::Definition::InterfaceMixin(mixin) => {
+                    interfacemap.insert(parse_mixin_name(&mixin), ParsedInterface {
+                        name: parse_mixin_name(&mixin),
+                        inherits_from: None,
+                        attributes: mixin
+                        .members
+                        .body
+                        .iter()
+                        .filter_map(parse_mixin_attributes)
+                        .collect::<Vec<_>>(),
+                        includes: Vec::new(),
+                    });
+                }
+                weedle::Definition::IncludesStatement(include) => {
+                    includes.push((include.lhs_identifier.0.to_string(), include.rhs_identifier.0.to_string()));
+                }
+                weedle::Definition::PartialInterface(interface) => {
+                    eprintln!("PARTIAL INTERFACE {}", interface.identifier.0);
+                    interfacemap.insert(interface.identifier.0.to_string(), ParsedInterface {
+                        name: interface.identifier.0.to_string(),
+                        inherits_from: None,
+                        attributes: interface
+                        .members
+                        .body
+                        .iter()
+                        .filter_map(parse_attributes)
+                        .collect::<Vec<_>>(),
+                        includes: Vec::new(),
+                    });
+                }
+                a => {
+                    eprintln!("Skipping {:?}", a);
+                }
             }
         }
     }
-    Ok(outputs)
+    for (i1, i2) in includes {
+        eprintln!("INCLUDE: {} <- {}", i1, i2);
+        if let Some(interface) = interfacemap.get_mut(&i1) {
+            eprintln!("Found {} to include {}", i1, i2);
+            interface.includes.push(i2);
+        }
+    }
+    Ok(interfacemap.values().cloned().collect())
 }
 
 fn parse_interface_name(interface: &weedle::InterfaceDefinition) -> String {
     interface.identifier.0.to_owned()
+}
+
+fn parse_mixin_name(mixin: &weedle::InterfaceMixinDefinition) -> String {
+    mixin.identifier.0.to_owned()
 }
 
 fn parse_inheritance(interface: &weedle::InterfaceDefinition) -> Option<String> {
@@ -54,6 +112,48 @@ fn parse_inheritance(interface: &weedle::InterfaceDefinition) -> Option<String> 
         .inheritance
         .map(|parent| parent.identifier.0.to_string())
 }
+
+fn parse_mixin_attributes(member: &MixinMember) -> Option<Attribute> {
+    if let MixinMember::Attribute(attr) = member {
+        // NOTE: we're skipping over all DOM-only methods for now.
+        if attr.readonly.is_some() {
+            return None;
+        }
+
+        let ty = match &attr.type_.type_ {
+            weedle::types::Type::Single(ty) => match ty {
+                weedle::types::SingleType::NonAny(ty) => match ty {
+                    weedle::types::NonAnyType::Integer(_) => AttributeType::Integer,
+                    weedle::types::NonAnyType::FloatingPoint(_) => AttributeType::Float,
+                    weedle::types::NonAnyType::Boolean(_) => AttributeType::Bool,
+                    weedle::types::NonAnyType::Object(_) => {
+                        // `js-sys` doesn't handle this either, so we just skip right past it.
+                        return None;
+                    }
+                    weedle::types::NonAnyType::USVString(_)
+                    | weedle::types::NonAnyType::DOMString(_) => AttributeType::String,
+                    weedle::types::NonAnyType::Identifier(id) => {
+                        AttributeType::Identifier(id.type_.0.to_owned())
+                    }
+                    ty => unreachable!("{ty:?} is not a recognized type"),
+                },
+                weedle::types::SingleType::Any(_) => return None,
+            },
+            _ => return None,
+        };
+        let field_name = attr.identifier.0.to_string().to_case(Case::Snake);
+        let field_name = super::normalize_field_name(&field_name);
+        Some(Attribute {
+            name: attr.identifier.0.to_string(),
+            field_name,
+            description: String::new(),
+            ty,
+        })
+    } else {
+        None
+    }
+}
+
 
 fn parse_attributes(member: &InterfaceMember) -> Option<Attribute> {
     if let InterfaceMember::Attribute(attr) = member {

--- a/crates/html-bindgen/src/parse/webidls.rs
+++ b/crates/html-bindgen/src/parse/webidls.rs
@@ -40,7 +40,6 @@ pub fn parse_webidls(
         for def in definitions {
             match def {
                 weedle::Definition::Interface(interface) => {
-                    eprintln!("INTERFACE INFO {} IS {:?}", parse_interface_name(&interface), interface.inheritance);
                     interfacemap.insert(parse_interface_name(&interface), ParsedInterface {
                         name: parse_interface_name(&interface),
                         inherits_from: parse_inheritance(&interface),
@@ -70,7 +69,6 @@ pub fn parse_webidls(
                     includes.push((include.lhs_identifier.0.to_string(), include.rhs_identifier.0.to_string()));
                 }
                 weedle::Definition::PartialInterface(interface) => {
-                    eprintln!("PARTIAL INTERFACE {}", interface.identifier.0);
                     interfacemap.insert(interface.identifier.0.to_string(), ParsedInterface {
                         name: interface.identifier.0.to_string(),
                         inherits_from: None,
@@ -90,9 +88,7 @@ pub fn parse_webidls(
         }
     }
     for (i1, i2) in includes {
-        eprintln!("INCLUDE: {} <- {}", i1, i2);
         if let Some(interface) = interfacemap.get_mut(&i1) {
-            eprintln!("Found {} to include {}", i1, i2);
             interface.includes.push(i2);
         }
     }

--- a/crates/html/src/lib.rs
+++ b/crates/html/src/lib.rs
@@ -122,3 +122,8 @@ where
 
 /// An HTML Element
 pub trait HtmlElement {}
+
+pub type EventHandler = String;
+pub type OnErrorEventHandler = String;
+pub type MediaProvider = String;
+pub type OnBeforeUnloadEventHandler = String;

--- a/resources/manual/global_attributes.json
+++ b/resources/manual/global_attributes.json
@@ -1,21 +1,9 @@
 [
     {
-        "name": "accesskey",
-        "description": "Provides a hint for generating a keyboard shortcut for the current element",
-        "field_name": "access_key",
-        "ty": "String"
-    },
-    {
         "name": "autocapitalize",
         "description": "Controls whether and how text input is automatically capitalized as it is entered/edited by the user",
         "field_name": "auto_capitalize",
         "ty": "String"
-    },
-    {
-        "name": "autofocus",
-        "description": "Indicates that an element should be focused on page load, or when the <dialog> that it is part of is displayed",
-        "field_name": "autofocus",
-        "ty": "Bool"
     },
     {
         "name": "class",
@@ -34,12 +22,6 @@
         "description": "Indicates the directionality of the element's text",
         "field_name": "direction",
         "ty": "String"
-    },
-    {
-        "name": "draggable",
-        "description": "Indicates whether the element can be dragged, either with native browser behavior or the HTML Drag and Drop API.",
-        "field_name": "draggable",
-        "ty": "Bool"
     },
     {
         "name": "enterkeyhint",
@@ -64,12 +46,6 @@
         "description": "Defines an identifier (ID) which must be unique in the whole document",
         "field_name": "id",
         "ty": "String"
-    },
-    {
-        "name": "inert",
-        "description": "indicating that the browser will ignore the element",
-        "field_name": "inert",
-        "ty": "Bool"
     },
     {
         "name": "inputmode",
@@ -114,18 +90,6 @@
         "ty": "String"
     },
     {
-        "name": "lang",
-        "description": "The lang global attribute helps define the language of an element: the language that non-editable elements are written in, or the language that the editable elements should be written in by the user",
-        "field_name": "lang",
-        "ty": "String"
-    },
-    {
-        "name": "nonce",
-        "description": "The nonce global attribute is a content attribute defining a cryptographic nonce (\"number used once\") which can be used by Content Security Policy to determine whether or not a given fetch will be allowed to proceed for a given element",
-        "field_name": "nonce",
-        "ty": "String"
-    },
-    {
         "name": "part",
         "description": "The part global attribute contains a space-separated list of the part names of the element",
         "field_name": "part",
@@ -138,33 +102,9 @@
         "ty": "String"
     },
     {
-        "name": "spellcheck",
-        "description": "The spellcheck global attribute is an enumerated attribute that defines whether the element may be checked for spelling errors",
-        "field_name": "spellcheck",
-        "ty": "String"
-    },
-    {
         "name": "style",
         "description": "The style global attribute contains CSS styling declarations to be applied to the element",
         "field_name": "style",
         "ty": "String"
-    },
-    {
-        "name": "tabindex",
-        "description": "The tabindex global attribute allows developers to make HTML elements focusable, allow or prevent them from being sequentially focusable (usually with the Tab key, hence the name) and determine their relative ordering for sequential focus navigation",
-        "field_name": "tab_index",
-        "ty": "Integer"
-    },
-    {
-        "name": "title",
-        "description": "The title global attribute contains text representing advisory information related to the element it belongs to",
-        "field_name": "title",
-        "ty": "String"
-    },
-    {
-        "name": "translate",
-        "description": "The translate global attribute is an enumerated attribute that is used to specify whether an element's translatable attribute values and its Text node children should be translated when the page is localized, or whether to leave them unchanged",
-        "field_name": "translate",
-        "ty": "Bool"
     }
 ]


### PR DESCRIPTION
This pull request adds some functionality to the parser, adding what is in the GlobalEventHandlers and HtmlElement to the generated code.

I wanted to put this pull request and get some thoughts on the modifications. There are a few spots where I added includes that aren't necessary 100% of the time.